### PR TITLE
Strip markdown fences from generated code

### DIFF
--- a/examples/multi_code_agent/rest/code_agent.py
+++ b/examples/multi_code_agent/rest/code_agent.py
@@ -14,22 +14,15 @@ class CodeAgent:
     def __init__(self):
         self.llm = ChatOpenAI(model="gpt-4o", temperature=0)
         self.system_prompt = (
-            "You are a Python coding agent. "
-            "Your job is to write Python code based on "
-            "the user's query and plan. "
-            "IMPORTANT GUIDELINES:\n"
+            "You are a Python coding agent. Your job is to write Python code based on "
+            "the user's query and plan. IMPORTANT GUIDELINES:\n"
             "1. Write clean, executable Python code\n"
             "2. Include necessary imports\n"
-            "3. Make sure the code can be executed in a "
-            "Python environment\n"
-            "4. If the task requires external libraries, use "
-            "common ones like requests, pandas, numpy, etc.\n"
-            "5. Return only the Python code, no explanations "
-            "unless in comments\n"
-            "6. If historical context is provided, learn from "
-            "previous failures and avoid repeating the same mistakes\n"
-            "Your response should be ONLY the Python code "
-            "that solves the problem.")
+            "3. Make sure the code can be executed in a Python environment\n"
+            "4. If the task requires external libraries, use common ones like requests, pandas, numpy, etc.\n"
+            "5. Return only the Python code, no explanations unless in comments\n"
+            "6. If historical context is provided, learn from previous failures and avoid repeating the same mistakes\n"
+            "Your response should be ONLY the Python code that solves the problem.")
         self.code_prompt = ChatPromptTemplate.from_messages([
             ("system", self.system_prompt),
             ("human", ("{query}\n\nPlan: {plan}\n\n"
@@ -58,16 +51,11 @@ class CodeAgent:
         # Clean up the response to extract just the code
         code = response.content.strip()
 
-        # Remove markdown code blocks if present
-        if code.startswith("```python"):
-            code = code[9:]
-        elif code.startswith("```"):
-            code = code[3:]
+        # Remove markdown fences and code blocks if present
+        # This prevents stray ``` lines causing syntax errors
+        filtered_lines = [line for line in code.splitlines() if not line.strip().startswith("```")]
+        code = "\n".join(filtered_lines)
 
-        if code.endswith("```"):
-            code = code[:-3]
-
-        code = code.strip()
         logger.info(f"Generated code:\n{code}")
         return code
 


### PR DESCRIPTION
This patch removes any markdown fences (``` or ```python) from the generated code string before execution to prevent syntax errors.