### PR TITLE
Migrate to the new traceroot python sdk [3/n]

### DIFF
--- a/traceroot/__init__.py
+++ b/traceroot/__init__.py
@@ -123,6 +123,8 @@ def shutdown() -> None:
 
 
 __all__ = [
+    # Version
+    "__version__",
     # Core
     "initialize",
     "get_client",

--- a/traceroot/__init__.py
+++ b/traceroot/__init__.py
@@ -32,7 +32,7 @@ from traceroot.decorators import observe
 from traceroot.instrumentation import Integration
 from traceroot.update import update_current_span, update_current_trace
 
-__version__ = "0.1.0"
+from traceroot.constants import SDK_VERSION as __version__
 
 # =============================================================================
 # Global Singleton Client
@@ -125,6 +125,7 @@ def shutdown() -> None:
 __all__ = [
     # Core
     "initialize",
+    "get_client",
     "flush",
     "shutdown",
     "observe",

--- a/traceroot/constants.py
+++ b/traceroot/constants.py
@@ -5,6 +5,7 @@ tracer identification, and type definitions.
 """
 
 import enum
+import importlib.metadata
 
 # =============================================================================
 # SDK Identification
@@ -16,8 +17,8 @@ TRACEROOT_TRACER_NAME = "traceroot-sdk"
 SDK_NAME = "traceroot-python"
 """SDK name for identification in API requests."""
 
-SDK_VERSION = "0.1.0"
-"""SDK version. Should match pyproject.toml version."""
+SDK_VERSION = importlib.metadata.version("traceroot")
+"""SDK version. Read from package metadata (pyproject.toml)."""
 
 # =============================================================================
 # Default Values


### PR DESCRIPTION
as titled.