### PR TITLE
[Docs] Update READMD doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Documentation
 
-Please see the [Python SDK Docs](https://docs.traceroot.ai/sdk/python) for details.
+Please see the [Python SDK Docs](https://traceroot.ai/docs/tracing/get-started) for details.
 
 <!-- Links -->
 


### PR DESCRIPTION
Update documentation link in README from docs.traceroot.ai/sdk/python to traceroot.ai/docs/tracing/get-started