### PR TITLE
Replace deprecated api.traceroot.ai with app.traceroot.ai

### DIFF
--- a/traceroot/constants.py
+++ b/traceroot/constants.py
@@ -24,7 +24,7 @@ SDK_VERSION = importlib.metadata.version("traceroot")
 # Default Values
 # =============================================================================
 
-DEFAULT_HOST_URL = "https://api.traceroot.ai"
+DEFAULT_HOST_URL = "https://app.traceroot.ai"
 """Default Traceroot API endpoint."""
 
 DEFAULT_FLUSH_AT = 100

--- a/traceroot/env.py
+++ b/traceroot/env.py
@@ -35,7 +35,7 @@ TRACEROOT_HOST_URL = "TRACEROOT_HOST_URL"
 
 Base URL of the Traceroot API endpoint.
 
-**Default:** ``https://api.traceroot.ai``
+**Default:** ``https://app.traceroot.ai``
 """
 
 TRACEROOT_TIMEOUT = "TRACEROOT_TIMEOUT"


### PR DESCRIPTION
## Summary
- Replace deprecated `https://api.traceroot.ai` with `https://app.traceroot.ai` in `constants.py` (default host URL) and `env.py` (docstring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)