### PR TITLE
Loosen dependency version pins to fix install conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,13 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.0,<3.0",
-    "opentelemetry-api==1.40.0",
-    "opentelemetry-sdk==1.40.0",
-    "opentelemetry-exporter-otlp-proto-http==1.40.0",
-    "openinference-instrumentation==0.1.46",
-    "openinference-instrumentation-openai==0.1.42",
-    "openinference-instrumentation-anthropic==1.0.0",
-    "openinference-instrumentation-langchain==0.1.61",
+    "opentelemetry-api>=1.35.0,<2.0",
+    "opentelemetry-sdk>=1.35.0,<2.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.35.0,<2.0",
+    "openinference-instrumentation>=0.1.40,<1.0",
+    "openinference-instrumentation-openai>=0.1.40,<1.0",
+    "openinference-instrumentation-anthropic>=0.1.0,<2.0",
+    "openinference-instrumentation-langchain>=0.1.50,<1.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-http>=1.35.0,<2.0",
     "openinference-instrumentation>=0.1.40,<1.0",
     "openinference-instrumentation-openai>=0.1.40,<1.0",
-    "openinference-instrumentation-anthropic>=0.1.0,<2.0",
+    "openinference-instrumentation-anthropic>=1.0.0,<2.0",
     "openinference-instrumentation-langchain>=0.1.50,<1.0",
 ]
 


### PR DESCRIPTION
Fixes #85

## What changed

Replaced exact `==` version pins for OpenTelemetry and openinference packages with minimum-version + major-ceiling constraints (`>=x.y,<next_major`), matching the pattern already used by our `pydantic` dependency.

**Before:**
```toml
"opentelemetry-api==1.40.0",
"opentelemetry-sdk==1.40.0",
"opentelemetry-exporter-otlp-proto-http==1.40.0",
"openinference-instrumentation==0.1.46",
...
```

**After:**
```toml
"opentelemetry-api>=1.35.0,<2.0",
"opentelemetry-sdk>=1.35.0,<2.0",
"opentelemetry-exporter-otlp-proto-http>=1.35.0,<2.0",
"openinference-instrumentation>=0.1.40,<1.0",
...
```

## Why this is the right fix

Exact pins (`==`) cause hard install failures when a user already has a different version of the same package installed — pip has no room to negotiate. This is a critical problem for traceroot specifically because:

1. **Our target users already have OTel.** OpenTelemetry is the foundation of nearly every observability tool (Datadog, Langfuse, Arize Phoenix, Honeycomb, etc.). Anyone doing LLM observability likely has it already.
2. **Exact pins don't belong in libraries.** Exact pins are appropriate in *applications* (lockfiles, Docker images) where you control the full environment. In a *library* like traceroot, you're a guest in the user's environment — you should declare the minimum you need, not force a specific version.
3. **`<next_major` ceiling is the safe contract.** OTel follows semver, so `<2.0` means we won't silently pull in a breaking major version. The openinference packages are pre-1.0 so we cap at `<1.0` for the same reason.

The range chosen (`>=1.35.0` for OTel) gives ~5 releases of wiggle room behind the current tested version (1.40.0) without going so far back that we can't guarantee behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)