### PR TITLE
[Integrations] Add Gemini (google-genai) integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "openinference-instrumentation-openai>=0.1.40,<1.0",
     "openinference-instrumentation-anthropic>=1.0.0,<2.0",
     "openinference-instrumentation-langchain>=0.1.50,<1.0",
-    "openinference-instrumentation-google-genai>=0.1.0,<1.0",
+    "openinference-instrumentation-google-genai>=0.1.14,<1.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = {text = "Apache-2.0"}
 authors = [
     {name = "TraceRoot Team"},
 ]
-keywords = ["observability", "llm", "tracing", "openai", "anthropic"]
+keywords = ["observability", "llm", "tracing", "openai", "anthropic", "gemini"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -27,6 +27,7 @@ dependencies = [
     "openinference-instrumentation-openai>=0.1.40,<1.0",
     "openinference-instrumentation-anthropic>=1.0.0,<2.0",
     "openinference-instrumentation-langchain>=0.1.50,<1.0",
+    "openinference-instrumentation-google-genai>=0.1.0,<1.0",
 ]
 
 [dependency-groups]

--- a/tests/test_auto_instrumentation.py
+++ b/tests/test_auto_instrumentation.py
@@ -22,6 +22,7 @@ def test_integration_enum_values():
     assert Integration.OPENAI == "openai"
     assert Integration.ANTHROPIC == "anthropic"
     assert Integration.LANGCHAIN == "langchain"
+    assert Integration.GEMINI == "gemini"
 
 
 def test_integration_exported_from_traceroot():

--- a/tests/test_auto_instrumentation.py
+++ b/tests/test_auto_instrumentation.py
@@ -22,7 +22,7 @@ def test_integration_enum_values():
     assert Integration.OPENAI == "openai"
     assert Integration.ANTHROPIC == "anthropic"
     assert Integration.LANGCHAIN == "langchain"
-    assert Integration.GEMINI == "gemini"
+    assert Integration.GOOGLE_GENAI == "google_genai"
 
 
 def test_integration_exported_from_traceroot():

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -21,6 +21,7 @@ class Integration(StrEnum):
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
     LANGCHAIN = "langchain"
+    GEMINI = "gemini"
 
 
 # Maps Integration enum ->
@@ -40,6 +41,11 @@ _BUILTIN_REGISTRY: dict[Integration, tuple[str, str, str]] = {
         "langchain",
         "openinference.instrumentation.langchain",
         "LangChainInstrumentor",
+    ),
+    Integration.GEMINI: (
+        "google-genai",
+        "openinference.instrumentation.google_genai",
+        "GoogleGenAIInstrumentor",
     ),
 }
 

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -21,7 +21,7 @@ class Integration(StrEnum):
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
     LANGCHAIN = "langchain"
-    GEMINI = "gemini"
+    GOOGLE_GENAI = "google_genai"
 
 
 # Maps Integration enum ->
@@ -42,7 +42,7 @@ _BUILTIN_REGISTRY: dict[Integration, tuple[str, str, str]] = {
         "openinference.instrumentation.langchain",
         "LangChainInstrumentor",
     ),
-    Integration.GEMINI: (
+    Integration.GOOGLE_GENAI: (
         "google-genai",
         "openinference.instrumentation.google_genai",
         "GoogleGenAIInstrumentor",


### PR DESCRIPTION
## Summary
Closes #90

Adds Google Gemini as an auto-instrumentation target using the new `google-genai` SDK and its corresponding OpenInference instrumentor.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [x] build - Changes that affect the build system or external dependencies
- [ ] ci - Changes to our CI configuration files and scripts
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit

## Details
- Added `Integration.GEMINI` to the `Integration` enum in `registry.py`
- Registered Gemini in `_BUILTIN_REGISTRY` pointing to `openinference.instrumentation.google_genai.GoogleGenAIInstrumentor`
- Targets the new `google-genai` package — the old `google-generativeai` package is fully deprecated by Google and no longer supported by OpenInference

## Checklist

- [x] I have added/updated tests where applicable
- [ ] I have updated documentation where necessary (website docs at https://traceroot.ai/docs/tracing/python-sdk will need to be updated to include Gemini)
