### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "traceroot"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python SDK for TraceRoot"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump `traceroot` package version from `0.1.0` to `0.1.1`

## Changes included in this release
- SDK name renamed from `traceroot-python` to `traceroot-py` for consistency with `traceroot-ts`
- Improved SDK integration smoothness and added streaming generator support
- README improvements

## Test plan
- [x] Merge this PR
- [x] Run `gh release create v0.1.1 --generate-notes --title "v0.1.1"` to trigger PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)