### PR TITLE
feat: add Integration.OPENAI_AGENTS to SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "openinference-instrumentation-anthropic>=1.0.0,<2.0",
     "openinference-instrumentation-langchain>=0.1.50,<1.0",
     "openinference-instrumentation-google-genai>=0.1.14,<1.0",
+    "openinference-instrumentation-openai-agents>=0.1.0,<2.0",
 ]
 
 [dependency-groups]

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -22,6 +22,7 @@ class Integration(StrEnum):
     ANTHROPIC = "anthropic"
     LANGCHAIN = "langchain"
     GOOGLE_GENAI = "google_genai"
+    OPENAI_AGENTS = "openai_agents"
 
 
 # Maps Integration enum ->
@@ -46,6 +47,11 @@ _BUILTIN_REGISTRY: dict[Integration, tuple[str, str, str]] = {
         "google-genai",
         "openinference.instrumentation.google_genai",
         "GoogleGenAIInstrumentor",
+    ),
+    Integration.OPENAI_AGENTS: (
+        "openai-agents",
+        "openinference.instrumentation.openai_agents",
+        "OpenAIAgentsInstrumentor",
     ),
 }
 


### PR DESCRIPTION
 ## Summary
  Add OpenAI Agents SDK as a supported auto-instrumentation target.

  ## Type of Change
  - [x] feat - A new feature

  ## Details

  Users can now instrument the OpenAI Agents SDK with a single line:

  ```python
  import traceroot
  from traceroot import Integration

  traceroot.initialize(integrations=[Integration.OPENAI_AGENTS])
```
  Changes:
  - traceroot/instrumentation/registry.py: Added OPENAI_AGENTS = "openai_agents" to Integration enum + registry mapping to OpenAIAgentsInstrumentor
  - pyproject.toml: Added openinference-instrumentation-openai-agents>=0.1.0,<2.0 to dependencies

  Tested and working — traces with model name, token counts, and cost confirmed on staging.

  ## Screenshot
  
<img width="3332" height="1742" alt="image" src="https://github.com/user-attachments/assets/d53fe241-7608-46ba-9707-352f042f3e0e" />

  ## Checklist

  - I have read the ../CONTRIBUTING.md
  - I have added/updated tests where applicable
  - I have updated documentation where necessary
