### PR TITLE
feat: add Integration.CLAUDE_AGENT_SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "openinference-instrumentation-langchain>=0.1.50,<1.0",
     "openinference-instrumentation-google-genai>=0.1.14,<1.0",
     "openinference-instrumentation-openai-agents>=0.1.0,<2.0",
+    "openinference-instrumentation-claude-agent-sdk>=0.1.0,<2.0",
 ]
 
 [dependency-groups]

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -23,6 +23,7 @@ class Integration(StrEnum):
     LANGCHAIN = "langchain"
     GOOGLE_GENAI = "google_genai"
     OPENAI_AGENTS = "openai_agents"
+    CLAUDE_AGENT_SDK = "claude_agent_sdk"
 
 
 # Maps Integration enum ->
@@ -52,6 +53,11 @@ _BUILTIN_REGISTRY: dict[Integration, tuple[str, str, str]] = {
         "openai-agents",
         "openinference.instrumentation.openai_agents",
         "OpenAIAgentsInstrumentor",
+    ),
+    Integration.CLAUDE_AGENT_SDK: (
+        "claude-agent-sdk",
+        "openinference.instrumentation.claude_agent_sdk",
+        "ClaudeAgentSDKInstrumentor",
     ),
 }
 


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                         
  Add Claude Agent SDK as a supported auto-instrumentation target.
                                                                                                                                                                                                                                     
  ## Type of Change
  - [x] feat - A new feature                                                                                                                                                                                                         
                                                                                                                                                                                                                                     
  ## Details
                                                                                                                                                                                                                                     
  Users can now instrument the Claude Agent SDK with a single line:

  ```python
  import traceroot
  from traceroot import Integration
                                                                                                                                                                                                                                     
  traceroot.initialize(integrations=[Integration.CLAUDE_AGENT_SDK])
   ```                                                                                                                                                                                                                                  
   
 ## Changes:                                                  
  - traceroot/instrumentation/registry.py: Added CLAUDE_AGENT_SDK = "claude_agent_sdk" to Integration enum + registry mapping to ClaudeAgentSDKInstrumentor
  - pyproject.toml: Added openinference-instrumentation-claude-agent-sdk>=0.1.0,<2.0 to dependencies                                                                                                                                 
                                                                                                    
  Tested and working — traces confirmed on staging.                                                                                                                                                                                  
     ## Screenshot
         
<img width="3296" height="1760" alt="image" src="https://github.com/user-attachments/assets/53274792-2abd-4f2a-99fe-27451b422f0a" />

                                                                                                                                                                                                                      
    ## Checklist                                                                                                                                                                                                                          
                                                                                                                                                                                                                                     
  - I have read the ../CONTRIBUTING.md                                                                                                                                                                                               
  - I have added/updated tests where applicable
  - I have updated documentation where necessary                                