### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "traceroot"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python SDK for TraceRoot"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump version from `0.1.1` to `0.1.2` in `pyproject.toml`

## Release notes
This release adds `Integration.CLAUDE_AGENT_SDK` support for tracing claude-agent-sdk applications.

After merging, run:
```
gh release create v0.1.2 --title "v0.1.2" --notes "Add claude-agent-sdk integration support"
```
to trigger the PyPI publish workflow.