### PR TITLE
docs: add a complete contributing guide for local setup and workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,123 +2,37 @@
 
 Thanks for contributing to `traceroot-py`.
 
-## Development environment
+## Requirements
 
-You will need:
-
-- Python 3.11 or newer
+- Python 3.11+
 - `uv`
 - `git`
 
-## Fork and clone
-
-1. Fork the repository on GitHub.
-2. Clone your fork locally:
+## Setup
 
 ```bash
-git clone https://github.com/<your-username>/traceroot-py.git
+git clone https://github.com/traceroot-ai/traceroot-py.git
 cd traceroot-py
 ```
 
-3. Add the main repository as `upstream`:
+## Before you start
 
-```bash
-git remote add upstream https://github.com/traceroot-ai/traceroot-py.git
+- Check for an existing issue before starting larger work, or open one first so the change has clear scope.
+- Create branches from `main`. If you don't have push access, fork first.
+- Keep each pull request focused on one problem.
+
+## Workflow
+
+1. Create a branch from `main` using a short descriptive name (e.g. `feat/add-openai-instrumentation`, `fix/span-flush-timeout`).
+2. Make the smallest change that fully solves the issue.
+3. Run linting and tests locally before pushing.
+4. Open a pull request and link the related issue when applicable.
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
 ```
-
-## Local setup
-
-```bash
-uv sync --dev
-```
-
-To confirm the package imports correctly:
-
-```bash
-uv run python -c "import traceroot; print(traceroot.__version__)"
-```
-
-## Running locally
-
-This repository is a Python SDK, not a standalone CLI or service. In practice, "running locally"
-usually means either running the test suite or importing the SDK in a small script.
-
-Quick smoke test:
-
-```python
-import traceroot
-
-client = traceroot.initialize(enabled=False)
-print(traceroot.__version__)
-print(client.enabled)
-traceroot.shutdown()
-```
-
-Run it with:
-
-If you want to send real traces while testing locally, set `TRACEROOT_API_KEY` first.
-
-macOS/Linux example:
-
-```bash
-export TRACEROOT_API_KEY="your_api_key"
-uv run python smoke_test.py
-```
-
-PowerShell example:
-
-```powershell
-$env:TRACEROOT_API_KEY = "your_api_key"
-uv run python smoke_test.py
-```
-
-## Quality checks
-
-Run the basic checks locally:
-
-```bash
-uv run ruff check .
-uv run ruff format --check .
-uv run pytest
-```
-
-If you use pre-commit, you can also run:
-
-```bash
-uv tool run pre-commit run --all-files
-```
-
-## Best practices
-
-- Keep changes focused and easy to review.
-- Add or update tests when behavior changes.
-- Update docs when public APIs or behavior change.
-- Follow existing code patterns instead of introducing new styles unnecessarily.
-- Let Ruff handle formatting instead of formatting by hand.
-- Be mindful of backwards compatibility for public SDK behavior.
-
-## Branch naming
-
-Create branches from `main` and use short descriptive names:
-
-- `feat/add-openai-agent-instrumentation`
-- `fix/span-flush-timeout`
-- `docs/update-contributing`
-- `chore/bump-dev-dependencies`
-
-Suggested format:
-
-```text
-<type>/<short-description>
-```
-
-Avoid committing directly to `main`.
-
-## Conventional commits
-
-Use Conventional Commits for commit messages and, when helpful, PR titles:
-
-```text
 feat: add google genai instrumentation
 fix: handle missing git remote gracefully
 docs: expand contributing guide
@@ -126,28 +40,12 @@ test: cover disabled client initialization
 chore: bump development dependencies
 ```
 
-Common commit types:
-
-- `feat`
-- `fix`
-- `docs`
-- `refactor`
-- `test`
-- `chore`
-- `ci`
-- `build`
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `build`.
 
 ## Pull requests
 
-- Keep PRs focused and small enough to review quickly.
-- Fill out the pull request template clearly.
-- Make sure linting and tests pass locally before opening the PR.
-- Add or update tests and documentation where appropriate.
-
-## License
-
-This project is licensed under [Apache 2.0](LICENSE).
-
-When contributing to the TraceRoot codebase, you need to agree to the
-[Contributor License Agreement](https://cla-assistant.io/traceroot-ai/traceroot-py).
-You only need to do this once.
+- Keep PRs scoped to one logical change.
+- Explain what changed, why it changed, and how it was validated.
+- Add or update tests for behavior changes.
+- Update documentation for API or behavior changes.
+- Make sure linting and tests pass before requesting review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,11 +56,14 @@ traceroot.shutdown()
 
 Run it with:
 
+If you want to send real traces while testing locally, set `TRACEROOT_API_KEY` first.
+
+macOS/Linux example:
+
 ```bash
+export TRACEROOT_API_KEY="your_api_key"
 uv run python smoke_test.py
 ```
-
-If you want to send real traces while testing locally, set `TRACEROOT_API_KEY` first.
 
 PowerShell example:
 
@@ -146,5 +149,5 @@ Common commit types:
 This project is licensed under [Apache 2.0](LICENSE).
 
 When contributing to the TraceRoot codebase, you need to agree to the
-[Contributor License Agreement](https://cla-assistant.io/traceroot-ai/traceroot).
+[Contributor License Agreement](https://cla-assistant.io/traceroot-ai/traceroot-py).
 You only need to do this once.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,150 @@
-Coming Soon
+# Contributing
+
+Thanks for contributing to `traceroot-py`.
+
+## Development environment
+
+You will need:
+
+- Python 3.11 or newer
+- `uv`
+- `git`
+
+## Fork and clone
+
+1. Fork the repository on GitHub.
+2. Clone your fork locally:
+
+```bash
+git clone https://github.com/<your-username>/traceroot-py.git
+cd traceroot-py
+```
+
+3. Add the main repository as `upstream`:
+
+```bash
+git remote add upstream https://github.com/traceroot-ai/traceroot-py.git
+```
+
+## Local setup
+
+```bash
+uv sync --dev
+```
+
+To confirm the package imports correctly:
+
+```bash
+uv run python -c "import traceroot; print(traceroot.__version__)"
+```
+
+## Running locally
+
+This repository is a Python SDK, not a standalone CLI or service. In practice, "running locally"
+usually means either running the test suite or importing the SDK in a small script.
+
+Quick smoke test:
+
+```python
+import traceroot
+
+client = traceroot.initialize(enabled=False)
+print(traceroot.__version__)
+print(client.enabled)
+traceroot.shutdown()
+```
+
+Run it with:
+
+```bash
+uv run python smoke_test.py
+```
+
+If you want to send real traces while testing locally, set `TRACEROOT_API_KEY` first.
+
+PowerShell example:
+
+```powershell
+$env:TRACEROOT_API_KEY = "your_api_key"
+uv run python smoke_test.py
+```
+
+## Quality checks
+
+Run the basic checks locally:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest
+```
+
+If you use pre-commit, you can also run:
+
+```bash
+uv tool run pre-commit run --all-files
+```
+
+## Best practices
+
+- Keep changes focused and easy to review.
+- Add or update tests when behavior changes.
+- Update docs when public APIs or behavior change.
+- Follow existing code patterns instead of introducing new styles unnecessarily.
+- Let Ruff handle formatting instead of formatting by hand.
+- Be mindful of backwards compatibility for public SDK behavior.
+
+## Branch naming
+
+Create branches from `main` and use short descriptive names:
+
+- `feat/add-openai-agent-instrumentation`
+- `fix/span-flush-timeout`
+- `docs/update-contributing`
+- `chore/bump-dev-dependencies`
+
+Suggested format:
+
+```text
+<type>/<short-description>
+```
+
+Avoid committing directly to `main`.
+
+## Conventional commits
+
+Use Conventional Commits for commit messages and, when helpful, PR titles:
+
+```text
+feat: add google genai instrumentation
+fix: handle missing git remote gracefully
+docs: expand contributing guide
+test: cover disabled client initialization
+chore: bump development dependencies
+```
+
+Common commit types:
+
+- `feat`
+- `fix`
+- `docs`
+- `refactor`
+- `test`
+- `chore`
+- `ci`
+- `build`
+
+## Pull requests
+
+- Keep PRs focused and small enough to review quickly.
+- Fill out the pull request template clearly.
+- Make sure linting and tests pass locally before opening the PR.
+- Add or update tests and documentation where appropriate.
+
+## License
+
+This project is licensed under [Apache 2.0](LICENSE).
+
+When contributing to the TraceRoot codebase, you need to agree to the
+[Contributor License Agreement](https://cla-assistant.io/traceroot-ai/traceroot).
+You only need to do this once.


### PR DESCRIPTION
## Summary

Add a proper `CONTRIBUTING.md` for `traceroot-py` to help new contributors get started quickly.

### fixes #95 

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [x] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies
- [ ] ci - Changes to our CI configuration files and scripts
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit

## Details

This PR replaces the placeholder `CONTRIBUTING.md` with a contributor guide that includes:

- fork and clone instructions
- local development setup using `uv`
- how to smoke-test the SDK locally
- linting, formatting, and test commands
- contributor best practices
- branch naming guidance
- Conventional Commits examples
- pull request expectations
- license and CLA information

This is a documentation-only change and does not modify package behavior.

## Checklist

- [ ] I have added/updated tests where applicable
- [x] I have updated documentation where necessary
