### PR TITLE
[Integrations] Add AutoGen (ag2) integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "openinference-instrumentation-google-genai>=0.1.14,<1.0",
     "openinference-instrumentation-openai-agents>=0.1.0,<2.0",
     "openinference-instrumentation-claude-agent-sdk>=0.1.0,<2.0",
+    "openinference-instrumentation-autogen>=0.1.10,<1.0",
 ]
 
 [dependency-groups]

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -112,7 +112,11 @@ def initialize_integrations(
             module = importlib.import_module(module_path)
             instrumentor_cls = getattr(module, class_name)
             instrumentor = instrumentor_cls()
-            instrumentor.instrument(tracer_provider=tracer_provider)
+
+            try:
+                instrumentor.instrument(tracer_provider=tracer_provider)
+            except TypeError:
+                instrumentor.instrument()
 
             logger.info(
                 "Instrumented %s via %s.%s",

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -115,7 +115,9 @@ def initialize_integrations(
 
             try:
                 instrumentor.instrument(tracer_provider=tracer_provider)
-            except TypeError:
+            except TypeError as exc:
+                if "tracer_provider" not in str(exc):
+                    raise
                 instrumentor.instrument()
 
             logger.info(

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -113,12 +113,11 @@ def initialize_integrations(
             instrumentor_cls = getattr(module, class_name)
             instrumentor = instrumentor_cls()
 
-            try:
-                instrumentor.instrument(tracer_provider=tracer_provider)
-            except TypeError as exc:
-                if "tracer_provider" not in str(exc):
-                    raise
+            # AutoGen instrumentor (OpenInference) currently does not accept tracer_provider
+            if instrument is Integration.AUTOGEN:
                 instrumentor.instrument()
+            else:
+                instrumentor.instrument(tracer_provider=tracer_provider)
 
             logger.info(
                 "Instrumented %s via %s.%s",

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -24,6 +24,7 @@ class Integration(StrEnum):
     GOOGLE_GENAI = "google_genai"
     OPENAI_AGENTS = "openai_agents"
     CLAUDE_AGENT_SDK = "claude_agent_sdk"
+    AUTOGEN = "autogen"
 
 
 # Maps Integration enum ->
@@ -58,6 +59,11 @@ _BUILTIN_REGISTRY: dict[Integration, tuple[str, str, str]] = {
         "claude-agent-sdk",
         "openinference.instrumentation.claude_agent_sdk",
         "ClaudeAgentSDKInstrumentor",
+    ),
+    Integration.AUTOGEN: (
+        "ag2",
+        "openinference.instrumentation.autogen",
+        "AutogenInstrumentor",
     ),
 }
 
@@ -107,6 +113,7 @@ def initialize_integrations(
             instrumentor_cls = getattr(module, class_name)
             instrumentor = instrumentor_cls()
             instrumentor.instrument(tracer_provider=tracer_provider)
+
             logger.info(
                 "Instrumented %s via %s.%s",
                 library,

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -114,6 +114,7 @@ def initialize_integrations(
             instrumentor = instrumentor_cls()
 
             # AutoGen instrumentor (OpenInference) currently does not accept tracer_provider
+            # https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-autogen/src/openinference/instrumentation/autogen/__init__.py
             if instrument is Integration.AUTOGEN:
                 instrumentor.instrument()
             else:


### PR DESCRIPTION
## Summary

Adds an AutoGen (ag2) agent as an auto-instrumentation target through OpenInference auto-instrumentation.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [x] refactor - A code change that neither fixes a bug nor adds a feature
- [x] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies
- [ ] ci - Changes to our CI configuration files and scripts
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit

## Details
- Added `Integration.AUTOGEN` to the `Integration` enum in `registry.py`
- Registered AutoGen in `_BUILTIN_REGISTRY` pointing to `openinference.instrumentation.autogen.AutogenInstrumentor`
- Added explicit fallback in `initialize_integrations()` for instrumentors that don't accept `tracer_provider` (AutoGen's instrumentor currently lacks this parameter unlike other OpenInference integrations)
- Targets `ag2` package (the actively maintained fork of AutoGen) [See here](https://pypi.org/project/ag2/)
- Note: `openinference-instrumentation-autogen` is currently v0.1.10 and marked EXPERIMENTAL — API may shift with upstream changes

## Checklist

- [ ] I have added/updated tests where applicable
- [ ] I have updated documentation where necessary
