### PR TITLE
fix: lower opentelemetry minimum version to 1.34.0 for CrewAI SDK support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.0,<3.0",
-    "opentelemetry-api>=1.35.0,<2.0",
-    "opentelemetry-sdk>=1.35.0,<2.0",
-    "opentelemetry-exporter-otlp-proto-http>=1.35.0,<2.0",
+    "opentelemetry-api>=1.34.0,<2.0",
+    "opentelemetry-sdk>=1.34.0,<2.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.34.0,<2.0",
     "openinference-instrumentation>=0.1.40,<1.0",
     "openinference-instrumentation-crewai>=1.1.1,<2.0",
     "openinference-instrumentation-openai>=0.1.40,<1.0",


### PR DESCRIPTION
## Summary

- Lowers the minimum version constraint for `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-otlp-proto-http` from `>=1.35.0` to `>=1.34.0`

## Motivation

This change is required to unblock CrewAI SDK support in the main traceroot repo. The CrewAI SDK has a dependency on an older version of `opentelemetry` that is incompatible with the `>=1.35.0` lower bound we previously enforced. Lowering to `>=1.34.0` resolves the version conflict and allows the SDK integration to work correctly.

See: traceroot-ai/traceroot#670

## Test plan

- [ ] Verify that `pip install` resolves successfully with a CrewAI SDK environment
- [ ] Confirm existing OpenTelemetry instrumentation still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)