### PR TITLE
feat: add Integration.LLAMAINDEX to SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "openinference-instrumentation-google-genai>=0.1.14,<1.0",
     "openinference-instrumentation-openai-agents>=0.1.0,<2.0",
     "openinference-instrumentation-claude-agent-sdk>=0.1.0,<2.0",
+    "openinference-instrumentation-llama-index>=4.0.0,<5.0",
     "openinference-instrumentation-autogen>=0.1.10,<1.0",
 ]
 

--- a/tests/test_auto_instrumentation.py
+++ b/tests/test_auto_instrumentation.py
@@ -24,6 +24,7 @@ def test_integration_enum_values():
     assert Integration.GOOGLE_GENAI == "google_genai"
     assert Integration.OPENAI_AGENTS == "openai_agents"
     assert Integration.CREWAI == "crewai"
+    assert Integration.LLAMA_INDEX == "llama_index"
 
 
 def test_integration_exported_from_traceroot():
@@ -174,6 +175,75 @@ def test_crewai_can_be_requested_with_other_integrations(mock_installed):
         )
 
     assert result == [Integration.OPENAI, Integration.CREWAI]
+
+
+# =============================================================================
+# LlamaIndex integration
+# =============================================================================
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_llamaindex_integration_uses_llamaindex_instrumentor(mock_installed):
+    mock_installed.return_value = True
+    mock_instrumentor = MagicMock()
+    mock_cls = MagicMock(return_value=mock_instrumentor)
+    mock_module = MagicMock()
+    mock_module.LlamaIndexInstrumentor = mock_cls
+
+    provider = TracerProvider()
+
+    with patch("importlib.import_module", return_value=mock_module):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.LLAMA_INDEX],
+        )
+
+    assert result == [Integration.LLAMA_INDEX]
+    mock_cls.assert_called_once()
+    mock_instrumentor.instrument.assert_called_once_with(tracer_provider=provider)
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_llamaindex_missing_warns_and_skips(mock_installed, caplog):
+    import logging
+
+    mock_installed.return_value = False
+
+    provider = TracerProvider()
+    with caplog.at_level(logging.WARNING, logger="traceroot.instrumentation.registry"):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.LLAMA_INDEX],
+        )
+
+    assert result == []
+    assert "skipping" in caplog.text
+    assert "llama-index-core" in caplog.text
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_llamaindex_can_be_requested_with_other_integrations(mock_installed):
+    mock_installed.return_value = True
+
+    def import_module(name):
+        module = MagicMock()
+        if name == "openinference.instrumentation.llama_index":
+            module.LlamaIndexInstrumentor = MagicMock(return_value=MagicMock())
+        elif name == "openinference.instrumentation.openai":
+            module.OpenAIInstrumentor = MagicMock(return_value=MagicMock())
+        else:
+            raise AssertionError(f"unexpected module import: {name}")
+        return module
+
+    provider = TracerProvider()
+
+    with patch("importlib.import_module", side_effect=import_module):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.OPENAI, Integration.LLAMA_INDEX],
+        )
+
+    assert result == [Integration.OPENAI, Integration.LLAMA_INDEX]
 
 
 @patch("traceroot.instrumentation.registry._is_package_installed")

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -25,6 +25,7 @@ class Integration(StrEnum):
     CREWAI = "crewai"
     OPENAI_AGENTS = "openai_agents"
     CLAUDE_AGENT_SDK = "claude_agent_sdk"
+    LLAMA_INDEX = "llama_index"
     AUTOGEN = "autogen"
 
 
@@ -65,6 +66,11 @@ _BUILTIN_REGISTRY: dict[Integration, tuple[str, str, str]] = {
         "claude-agent-sdk",
         "openinference.instrumentation.claude_agent_sdk",
         "ClaudeAgentSDKInstrumentor",
+    ),
+    Integration.LLAMA_INDEX: (
+        "llama-index-core",
+        "openinference.instrumentation.llama_index",
+        "LlamaIndexInstrumentor",
     ),
     Integration.AUTOGEN: (
         "ag2",


### PR DESCRIPTION
 ## Summary 
  Add `Integration.LLAMA_INDEX` to the TraceRoot Python SDK.
                                              
  ## Type of Change                       
  - [x] feat - A new feature
                                                                                                                                                                                                                                        
  ## Details
                                                                                                                                                                                                                                        
  Users can now instrument LlamaIndex with a single line:   
                                          
  ```python
  import traceroot                                                                                                                                                                                                                      
  from traceroot import Integration
                                                                                                                                                                                                                                        
  traceroot.initialize(integrations=[Integration.LLAMAINDEX])
 ```                                   
  
  ## Changes:
  - traceroot/instrumentation/registry.py: Added LLAMAINDEX = "llamaindex" to Integration enum + registry mapping to LlamaIndexInstrumentor                                                                                             
  - pyproject.toml: Added openinference-instrumentation-llama-index>=0.1.0,<5.0 to dependencies                                            
                                                                                                                                                                                                                                        
  Tested and working — traces with RAG pipeline spans (retrieve, synthesize, LLM calls), token counts, and cost confirmed on staging.
     ## Screenshot         
<img width="3084" height="1746" alt="image" src="https://github.com/user-attachments/assets/ddb35c07-e1ba-491a-a089-f0a23f2c0c3a" />
                                                                                                                                                                                                                         
  ## Checklist                               
                                                                                                                                                                                                                                        
  - I have added/updated tests where applicable                                                                                                                                                                                         
  - I have updated documentation where necessary   