### PR TITLE
fix: remove trailing whitespace causing ruff lint failure

### DIFF
--- a/tests/test_auto_instrumentation.py
+++ b/tests/test_auto_instrumentation.py
@@ -299,7 +299,7 @@ def test_client_skips_instrumentation_when_disabled():
     with patch("traceroot.instrumentation.registry.initialize_integrations") as mock_init:
         traceroot.initialize(enabled=False, integrations=[Integration.OPENAI])
         mock_init.assert_not_called()
-        
+
 
 # =============================================================================
 # Agno integration


### PR DESCRIPTION
## Summary
- Removes trailing whitespace on line 302 of `tests/test_auto_instrumentation.py` introduced by the Agno integration PR
- This single whitespace character was causing the `ruff check` CI step to fail on main

## Test plan
- [ ] Verify CI lint check passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)