### PR TITLE
feat(instrumentation): add Mistral AI SDK integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "openinference-instrumentation-openai>=0.1.40,<1.0",
     "openinference-instrumentation-anthropic>=1.0.0,<2.0",
     "openinference-instrumentation-langchain>=0.1.50,<1.0",
+    "openinference-instrumentation-mistralai>=2.0.1,<3.0",
     "openinference-instrumentation-google-genai>=0.1.14,<1.0",
     "openinference-instrumentation-openai-agents>=0.1.0,<2.0",
     "openinference-instrumentation-claude-agent-sdk>=0.1.0,<2.0",

--- a/tests/test_auto_instrumentation.py
+++ b/tests/test_auto_instrumentation.py
@@ -441,3 +441,50 @@ def test_dspy_missing_warns_and_skips(mock_installed, caplog):
     assert result == []
     assert "skipping" in caplog.text
     assert "dspy" in caplog.text
+
+
+# =============================================================================
+# Mistral integration
+# =============================================================================
+
+
+def test_mistral_integration_enum_value():
+    assert Integration.MISTRAL == "mistral"
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_mistral_integration_uses_mistralai_instrumentor(mock_installed):
+    mock_installed.return_value = True
+    mock_instrumentor = MagicMock()
+    mock_cls = MagicMock(return_value=mock_instrumentor)
+    mock_module = MagicMock()
+    mock_module.MistralAIInstrumentor = mock_cls
+
+    provider = TracerProvider()
+
+    with patch("importlib.import_module", return_value=mock_module):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.MISTRAL],
+        )
+
+    assert result == [Integration.MISTRAL]
+    mock_instrumentor.instrument.assert_called_once_with(tracer_provider=provider)
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_mistral_missing_warns_and_skips(mock_installed, caplog):
+    import logging
+
+    mock_installed.return_value = False
+
+    provider = TracerProvider()
+    with caplog.at_level(logging.WARNING, logger="traceroot.instrumentation.registry"):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.MISTRAL],
+        )
+
+    assert result == []
+    assert "skipping" in caplog.text
+    assert "mistralai" in caplog.text

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -31,6 +31,7 @@ class Integration(StrEnum):
     GROQ = "groq"
     DSPY = "dspy"
     GOOGLE_ADK = "google_adk"
+    MISTRAL = "mistral"
 
 
 # Maps Integration enum ->
@@ -100,6 +101,11 @@ _BUILTIN_REGISTRY: dict[Integration, tuple[str, str, str]] = {
         "google-adk",
         "openinference.instrumentation.google_adk",
         "GoogleADKInstrumentor",
+    ),
+    Integration.MISTRAL: (
+        "mistralai",
+        "openinference.instrumentation.mistralai",
+        "MistralAIInstrumentor",
     ),
 }
 


### PR DESCRIPTION
## Summary
Adds `Integration.MISTRAL` to the TraceRoot Python SDK, enabling one-line
auto-instrumentation of [Mistral AI](https://mistral.ai/) API calls via
`openinference-instrumentation-mistralai`.
## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies
- [ ] ci - Changes to our CI configuration files and scripts
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit

## Details

- `registry.py` — add `Integration.MISTRAL = 'mistral'` to the Integration StrEnum and `_BUILTIN_REGISTRY` entry pointing to `MistralAIInstrumentor` from `openinference.instrumentation.mistralai`
- `pyproject.toml` — add `openinference-instrumentation-mistralai >=2.0.1,<3.0`
- `tests/test_auto_instrumentation.py` — add 3 tests matching existing pattern

## Usage

```python
import traceroot
from traceroot import Integration

traceroot.initialize(integrations=[Integration.MISTRAL])
```

## Checklist

- [x] I have added/updated tests where applicable
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Mistral SDK auto-instrumentation to the TraceRoot Python SDK. Enable tracing of `mistralai` API calls with `Integration.MISTRAL`.

- **New Features**
  - Added `Integration.MISTRAL` wired to `MistralAIInstrumentor` for one-line auto-instrumentation.
  - Added tests for enum value, instrumentor wiring, and missing-package warning.

- **Dependencies**
  - Added `openinference-instrumentation-mistralai>=2.0.1,<3.0`.

<sup>Written for commit ebfa9399fd573ada29f7795c3453126423cc9cb9. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/111?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

