### PR TITLE
[Integrations] Add Google ADK integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "openinference-instrumentation-claude-agent-sdk>=0.1.0,<2.0",
     "openinference-instrumentation-llama-index>=4.0.0,<5.0",
     "openinference-instrumentation-autogen>=0.1.10,<1.0",
+    "openinference-instrumentation-google-adk>=0.1.10,<1.0",
 ]
 
 [project.optional-dependencies]

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -30,6 +30,7 @@ class Integration(StrEnum):
     AGNO = "agno"
     GROQ = "groq"
     DSPY = "dspy"
+    GOOGLE_ADK = "google_adk"
 
 
 # Maps Integration enum ->
@@ -94,6 +95,11 @@ _BUILTIN_REGISTRY: dict[Integration, tuple[str, str, str]] = {
         "dspy",
         "openinference.instrumentation.dspy",
         "DSPyInstrumentor",
+    ),
+    Integration.GOOGLE_ADK: (
+        "google-adk",
+        "openinference.instrumentation.google_adk",
+        "GoogleADKInstrumentor",
     ),
 }
 


### PR DESCRIPTION
## Summary
Adds Google ADK as an auto-instrumentation target through OpenInference auto-instrumentation.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [x] build - Changes that affect the build system or external dependencies
- [ ] ci - Changes to our CI configuration files and scripts
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit

## Details
- Added `Integration.GOOGLE_ADK` to the `Integration` enum in `registry.py`
- Registered Google ADK in `_BUILTIN_REGISTRY` pointing to `openinference.instrumentation.google_adk.GoogleADKInstrumentor`
- Added `openinference-instrumentation-google-adk>=0.1.10,<1.0` to dependencies in `pyproject.toml`
- `GoogleADKInstrumentor` accepts `tracer_provider` normally — no special case needed unlike AutoGen
- Targets `google-adk` package — [openinference instrumentation package](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-google-adk)

## Checklist

- [ ] I have added/updated tests where applicable
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google ADK as an auto-instrumentation target via OpenInference. Enables tracing for `google-adk` apps through the integration registry.

- **New Features**
  - Added `Integration.GOOGLE_ADK` and registered `openinference.instrumentation.google_adk.GoogleADKInstrumentor`.
  - Targets the `google-adk` package; uses the standard `tracer_provider`.

- **Dependencies**
  - Added `openinference-instrumentation-google-adk>=0.1.10,<1.0`.

<sup>Written for commit e5a286b8829157d163a648cca099cfe471ea337e. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/112?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

