### PR TITLE
chore(claude): align .claude/settings.json with traceroot repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,10 @@
   "permissions": {
     "defaultMode": "bypassPermissions"
   },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_FORK_SUBAGENT": "1"
+  },
   "hooks": {
     "PostToolUse": [
       {
@@ -15,5 +19,9 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary

- Add `env` block with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` and `CLAUDE_CODE_FORK_SUBAGENT=1`
- Add `enabledPlugins` block with `superpowers` and `code-simplifier` from `claude-plugins-official`

Brings `.claude/settings.json` in line with [traceroot-ai/traceroot's settings.json](https://github.com/traceroot-ai/traceroot/blob/main/.claude/settings.json) so contributors using Claude Code get the same experimental features and plugin set across both repos.

Closes #114

## Test plan

- [ ] Open this repo with Claude Code and confirm the env vars and plugins are picked up
- [ ] Confirm existing `PostToolUse` lint hook still runs on Edit/Write

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `.claude/settings.json` with the traceroot repo so Claude Code uses the same experimental features and plugins (closes #114). Adds env `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` and `CLAUDE_CODE_FORK_SUBAGENT=1`, and enables `superpowers@claude-plugins-official` and `code-simplifier@claude-plugins-official`.

<sup>Written for commit 41f4ab4cadc80d83451d83a495c14b9b5d1478b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

