### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "traceroot"
-version = "0.1.4"
+version = "0.1.5"
 description = "Python SDK for TraceRoot"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bump version to 0.1.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `traceroot` version to 0.1.5 in `pyproject.toml` to publish the next patch release.

<sup>Written for commit ae226f411376f8da6b74eee685646e5eb20204f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

