### PR TITLE
feat(sdk): add Pydantic-AI instrumentation adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "openinference-instrumentation-llama-index>=4.0.0,<5.0",
     "openinference-instrumentation-autogen>=0.1.10,<1.0",
     "openinference-instrumentation-google-adk>=0.1.10,<1.0",
+    "openinference-instrumentation-pydantic-ai>=0.1.15,<1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_auto_instrumentation.py
+++ b/tests/test_auto_instrumentation.py
@@ -1,11 +1,13 @@
 """Tests for auto-instrumentation registry and initialization."""
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 from opentelemetry.sdk.trace import TracerProvider
 
 import traceroot
 from tests.utils import reset_traceroot
+from traceroot.instrumentation._instrumentors import AutogenInstrumentor, PydanticAIInstrumentor
 from traceroot.instrumentation.registry import (
     Integration,
     _is_package_installed,
@@ -26,6 +28,7 @@ def test_integration_enum_values():
     assert Integration.CREWAI == "crewai"
     assert Integration.LLAMA_INDEX == "llama_index"
     assert Integration.DSPY == "dspy"
+    assert Integration.PYDANTIC_AI == "pydantic_ai"
 
 
 def test_integration_exported_from_traceroot():
@@ -488,3 +491,141 @@ def test_mistral_missing_warns_and_skips(mock_installed, caplog):
     assert result == []
     assert "skipping" in caplog.text
     assert "mistralai" in caplog.text
+
+
+# =============================================================================
+# Pydantic AI integration
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_custom_instrumentors():
+    """Reset adapter instrumentor flags before and after each test."""
+    AutogenInstrumentor._instrumented = False
+    PydanticAIInstrumentor._instrumented = False
+    yield
+    AutogenInstrumentor._instrumented = False
+    PydanticAIInstrumentor._instrumented = False
+
+
+def test_pydantic_ai_integration_enum_value():
+    assert Integration.PYDANTIC_AI == "pydantic_ai"
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_pydantic_ai_skipped_if_not_installed(mock_installed, caplog):
+    import logging
+
+    mock_installed.return_value = False
+
+    provider = TracerProvider()
+    with caplog.at_level(logging.WARNING, logger="traceroot.instrumentation.registry"):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.PYDANTIC_AI],
+        )
+
+    assert result == []
+    assert "skipping" in caplog.text
+    assert "pydantic-ai" in caplog.text
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_pydantic_ai_installs_processor_and_calls_instrument_all(mock_installed):
+    import sys
+
+    mock_installed.return_value = True
+
+    mock_processor = MagicMock()
+    mock_processor_cls = MagicMock(return_value=mock_processor)
+    mock_agent_cls = MagicMock()
+
+    provider = MagicMock(spec=TracerProvider)
+
+    # Pass sys.modules (the object) not "sys.modules" (a string) so patch.dict
+    # doesn't try to resolve it via importlib and hit an unrelated mock.
+    with patch.dict(
+        sys.modules,
+        {
+            "openinference.instrumentation.pydantic_ai": MagicMock(
+                OpenInferenceSpanProcessor=mock_processor_cls
+            ),
+            "pydantic_ai": MagicMock(Agent=mock_agent_cls),
+        },
+    ):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.PYDANTIC_AI],
+        )
+
+    assert result == [Integration.PYDANTIC_AI]
+    mock_processor_cls.assert_called_once_with()
+    provider.add_span_processor.assert_called_once_with(mock_processor)
+    mock_agent_cls.instrument_all.assert_called_once_with()
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_pydantic_ai_idempotent(mock_installed):
+    """Calling initialize_integrations twice must not add the processor twice."""
+    import sys
+
+    mock_installed.return_value = True
+
+    mock_processor = MagicMock()
+    mock_processor_cls = MagicMock(return_value=mock_processor)
+    mock_agent_cls = MagicMock()
+
+    provider = MagicMock(spec=TracerProvider)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "openinference.instrumentation.pydantic_ai": MagicMock(
+                OpenInferenceSpanProcessor=mock_processor_cls
+            ),
+            "pydantic_ai": MagicMock(Agent=mock_agent_cls),
+        },
+    ):
+        initialize_integrations(provider, [Integration.PYDANTIC_AI])
+        initialize_integrations(provider, [Integration.PYDANTIC_AI])
+
+    assert provider.add_span_processor.call_count == 1
+    assert mock_agent_cls.instrument_all.call_count == 1
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_pydantic_ai_can_be_requested_with_other_integrations(mock_installed):
+    import sys
+
+    mock_installed.return_value = True
+
+    mock_oi_processor = MagicMock()
+    mock_agent_cls = MagicMock()
+    mock_openai_instrumentor = MagicMock()
+    mock_openai_cls = MagicMock(return_value=mock_openai_instrumentor)
+
+    provider = MagicMock(spec=TracerProvider)
+
+    # Inject all third-party modules via sys.modules so importlib.import_module
+    # finds them via the cache without importing or patching the function itself.
+    # traceroot.instrumentation._instrumentors is our own module and imports normally.
+    with patch.dict(
+        sys.modules,
+        {
+            "openinference.instrumentation.openai": MagicMock(OpenAIInstrumentor=mock_openai_cls),
+            "openinference.instrumentation.pydantic_ai": MagicMock(
+                OpenInferenceSpanProcessor=MagicMock(return_value=mock_oi_processor)
+            ),
+            "pydantic_ai": MagicMock(Agent=mock_agent_cls),
+        },
+    ):
+        result = initialize_integrations(
+            provider,
+            [Integration.OPENAI, Integration.PYDANTIC_AI],
+        )
+
+    assert Integration.OPENAI in result
+    assert Integration.PYDANTIC_AI in result
+    mock_openai_instrumentor.instrument.assert_called_once_with(tracer_provider=provider)
+    provider.add_span_processor.assert_called_once_with(mock_oi_processor)
+    mock_agent_cls.instrument_all.assert_called_once_with()

--- a/tests/test_auto_instrumentation.py
+++ b/tests/test_auto_instrumentation.py
@@ -1,8 +1,8 @@
 """Tests for auto-instrumentation registry and initialization."""
 
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
 from opentelemetry.sdk.trace import TracerProvider
 
 import traceroot

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,7 +11,10 @@ def create_uuid() -> str:
 def reset_traceroot() -> None:
     """Reset Traceroot global state between tests."""
     import traceroot
+    from traceroot.instrumentation._instrumentors import AutogenInstrumentor, PydanticAIInstrumentor
 
     if traceroot.get_client():
         traceroot.shutdown()
     traceroot._client = None
+    AutogenInstrumentor._instrumented = False
+    PydanticAIInstrumentor._instrumented = False

--- a/traceroot/instrumentation/_instrumentors.py
+++ b/traceroot/instrumentation/_instrumentors.py
@@ -1,0 +1,54 @@
+"""Adapter instrumentors for integrations that don't fit the standard OpenInference pattern.
+
+Each class exposes a uniform .instrument(tracer_provider=...) interface so the
+registry can treat every integration identically via InstrumentorEntry.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.trace import TracerProvider
+
+
+class AutogenInstrumentor:
+    """Wraps openinference AutogenInstrumentor, which does not accept tracer_provider."""
+
+    _instrumented: bool = False
+
+    def instrument(self, tracer_provider: TracerProvider | None = None, **_kwargs: object) -> None:
+        if AutogenInstrumentor._instrumented:
+            return
+        from openinference.instrumentation.autogen import AutogenInstrumentor as _Inner
+
+        _Inner().instrument()
+        AutogenInstrumentor._instrumented = True
+
+    def uninstrument(self, **_kwargs: object) -> None:
+        AutogenInstrumentor._instrumented = False
+
+
+class PydanticAIInstrumentor:
+    """Installs OpenInferenceSpanProcessor and calls Agent.instrument_all().
+
+    pydantic-ai emits native OTel GenAI semconv spans via its logfire integration.
+    OpenInferenceSpanProcessor reshapes those into the OpenInference attribute
+    schema that the traceroot backend understands.
+    """
+
+    _instrumented: bool = False
+
+    def instrument(self, tracer_provider: TracerProvider | None = None, **_kwargs: object) -> None:
+        if PydanticAIInstrumentor._instrumented:
+            return
+        from openinference.instrumentation.pydantic_ai import OpenInferenceSpanProcessor
+        from pydantic_ai import Agent
+
+        if tracer_provider is not None:
+            tracer_provider.add_span_processor(OpenInferenceSpanProcessor())
+        Agent.instrument_all()
+        PydanticAIInstrumentor._instrumented = True
+
+    def uninstrument(self, **_kwargs: object) -> None:
+        PydanticAIInstrumentor._instrumented = False

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -6,6 +6,7 @@ import importlib
 import importlib.metadata
 import logging
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -32,80 +33,101 @@ class Integration(StrEnum):
     DSPY = "dspy"
     GOOGLE_ADK = "google_adk"
     MISTRAL = "mistral"
+    PYDANTIC_AI = "pydantic_ai"
 
 
-# Maps Integration enum ->
-# (library to detect, instrumentor module path, instrumentor class name)
-_BUILTIN_REGISTRY: dict[Integration, tuple[str, str, str]] = {
-    Integration.OPENAI: (
-        "openai",
-        "openinference.instrumentation.openai",
-        "OpenAIInstrumentor",
+@dataclass
+class InstrumentorEntry:
+    """Registry entry: import module_path, get class_name, call .instrument()."""
+
+    package: str
+    module_path: str
+    class_name: str
+    # Alternative package names that also provide this integration (e.g. slim variants).
+    # The integration is considered available if *any* of package or alt_packages is installed.
+    alt_packages: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def all_packages(self) -> tuple[str, ...]:
+        return (self.package,) + self.alt_packages
+
+
+_BUILTIN_REGISTRY: dict[Integration, InstrumentorEntry] = {
+    Integration.OPENAI: InstrumentorEntry(
+        package="openai",
+        module_path="openinference.instrumentation.openai",
+        class_name="OpenAIInstrumentor",
     ),
-    Integration.ANTHROPIC: (
-        "anthropic",
-        "openinference.instrumentation.anthropic",
-        "AnthropicInstrumentor",
+    Integration.ANTHROPIC: InstrumentorEntry(
+        package="anthropic",
+        module_path="openinference.instrumentation.anthropic",
+        class_name="AnthropicInstrumentor",
     ),
-    Integration.LANGCHAIN: (
-        "langchain",
-        "openinference.instrumentation.langchain",
-        "LangChainInstrumentor",
+    Integration.LANGCHAIN: InstrumentorEntry(
+        package="langchain",
+        module_path="openinference.instrumentation.langchain",
+        class_name="LangChainInstrumentor",
     ),
-    Integration.GOOGLE_GENAI: (
-        "google-genai",
-        "openinference.instrumentation.google_genai",
-        "GoogleGenAIInstrumentor",
+    Integration.GOOGLE_GENAI: InstrumentorEntry(
+        package="google-genai",
+        module_path="openinference.instrumentation.google_genai",
+        class_name="GoogleGenAIInstrumentor",
     ),
-    Integration.CREWAI: (
-        "crewai",
-        "openinference.instrumentation.crewai",
-        "CrewAIInstrumentor",
+    Integration.CREWAI: InstrumentorEntry(
+        package="crewai",
+        module_path="openinference.instrumentation.crewai",
+        class_name="CrewAIInstrumentor",
     ),
-    Integration.OPENAI_AGENTS: (
-        "openai-agents",
-        "openinference.instrumentation.openai_agents",
-        "OpenAIAgentsInstrumentor",
+    Integration.OPENAI_AGENTS: InstrumentorEntry(
+        package="openai-agents",
+        module_path="openinference.instrumentation.openai_agents",
+        class_name="OpenAIAgentsInstrumentor",
     ),
-    Integration.CLAUDE_AGENT_SDK: (
-        "claude-agent-sdk",
-        "openinference.instrumentation.claude_agent_sdk",
-        "ClaudeAgentSDKInstrumentor",
+    Integration.CLAUDE_AGENT_SDK: InstrumentorEntry(
+        package="claude-agent-sdk",
+        module_path="openinference.instrumentation.claude_agent_sdk",
+        class_name="ClaudeAgentSDKInstrumentor",
     ),
-    Integration.LLAMA_INDEX: (
-        "llama-index-core",
-        "openinference.instrumentation.llama_index",
-        "LlamaIndexInstrumentor",
+    Integration.LLAMA_INDEX: InstrumentorEntry(
+        package="llama-index-core",
+        module_path="openinference.instrumentation.llama_index",
+        class_name="LlamaIndexInstrumentor",
     ),
-    Integration.AUTOGEN: (
-        "ag2",
-        "openinference.instrumentation.autogen",
-        "AutogenInstrumentor",
+    Integration.AUTOGEN: InstrumentorEntry(
+        package="ag2",
+        module_path="traceroot.instrumentation._instrumentors",
+        class_name="AutogenInstrumentor",
     ),
-    Integration.AGNO: (
-        "agno",
-        "openinference.instrumentation.agno",
-        "AgnoInstrumentor",
+    Integration.AGNO: InstrumentorEntry(
+        package="agno",
+        module_path="openinference.instrumentation.agno",
+        class_name="AgnoInstrumentor",
     ),
-    Integration.GROQ: (
-        "groq",
-        "openinference.instrumentation.groq",
-        "GroqInstrumentor",
+    Integration.GROQ: InstrumentorEntry(
+        package="groq",
+        module_path="openinference.instrumentation.groq",
+        class_name="GroqInstrumentor",
     ),
-    Integration.DSPY: (
-        "dspy",
-        "openinference.instrumentation.dspy",
-        "DSPyInstrumentor",
+    Integration.DSPY: InstrumentorEntry(
+        package="dspy",
+        module_path="openinference.instrumentation.dspy",
+        class_name="DSPyInstrumentor",
     ),
-    Integration.GOOGLE_ADK: (
-        "google-adk",
-        "openinference.instrumentation.google_adk",
-        "GoogleADKInstrumentor",
+    Integration.GOOGLE_ADK: InstrumentorEntry(
+        package="google-adk",
+        module_path="openinference.instrumentation.google_adk",
+        class_name="GoogleADKInstrumentor",
     ),
-    Integration.MISTRAL: (
-        "mistralai",
-        "openinference.instrumentation.mistralai",
-        "MistralAIInstrumentor",
+    Integration.MISTRAL: InstrumentorEntry(
+        package="mistralai",
+        module_path="openinference.instrumentation.mistralai",
+        class_name="MistralAIInstrumentor",
+    ),
+    Integration.PYDANTIC_AI: InstrumentorEntry(
+        package="pydantic-ai",
+        alt_packages=("pydantic-ai-slim",),
+        module_path="traceroot.instrumentation._instrumentors",
+        class_name="PydanticAIInstrumentor",
     ),
 }
 
@@ -131,45 +153,36 @@ def initialize_integrations(
 
     Returns:
         List of Integration values that were successfully instrumented.
-
-    Raises:
-        ImportError: If a requested library is not installed.
     """
     instrumented: list[Integration] = []
 
     for instrument in integrations:
-        library, module_path, class_name = _BUILTIN_REGISTRY[instrument]
+        entry = _BUILTIN_REGISTRY[instrument]
 
-        if not _is_package_installed(library):
+        if not any(_is_package_installed(p) for p in entry.all_packages):
+            all_pkgs = entry.all_packages
+            pkg_label = (
+                f"'{all_pkgs[0]}'"
+                if len(all_pkgs) == 1
+                else " or ".join(f"'{p}'" for p in all_pkgs)
+            )
             logger.warning(
-                "traceroot: skipping %s integration — '%s' is not installed. "
+                "traceroot: skipping %s integration — %s is not installed. "
                 "Install it with: pip install %s",
                 instrument.value,
-                library,
-                library,
+                pkg_label,
+                all_pkgs[0],
             )
             continue
 
         try:
-            module = importlib.import_module(module_path)
-            instrumentor_cls = getattr(module, class_name)
+            module = importlib.import_module(entry.module_path)
+            instrumentor_cls = getattr(module, entry.class_name)
             instrumentor = instrumentor_cls()
-
-            # AutoGen instrumentor (OpenInference) currently does not accept tracer_provider
-            # https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-autogen/src/openinference/instrumentation/autogen/__init__.py
-            if instrument is Integration.AUTOGEN:
-                instrumentor.instrument()
-            else:
-                instrumentor.instrument(tracer_provider=tracer_provider)
-
-            logger.info(
-                "Instrumented %s via %s.%s",
-                library,
-                module_path,
-                class_name,
-            )
+            instrumentor.instrument(tracer_provider=tracer_provider)
+            logger.info("Instrumented %s via %s", instrument.value, entry.module_path)
             instrumented.append(instrument)
         except Exception:
-            logger.warning("Failed to instrument %s", library, exc_info=True)
+            logger.warning("Failed to instrument %s", instrument.value, exc_info=True)
 
     return instrumented


### PR DESCRIPTION
## Summary

Fixes traceroot-ai/traceroot#736

## Summary

This PR adds first-class Pydantic-AI instrumentation support to the TraceRoot Python SDK.

Pydantic-AI does not follow the same instrumentation lifecycle as most existing integrations. Existing integrations generally expose an OpenInference `*Instrumentor` class with `.instrument(tracer_provider=...)`. 

Pydantic-AI instead emits native OpenTelemetry spans after framework instrumentation is enabled, and the OpenInference Pydantic-AI package provides a span processor that reshapes those spans into OpenInference-compatible attributes.

This PR keeps the public API simple:

```python
import traceroot
from traceroot import Integration

traceroot.initialize(integrations=[Integration.PYDANTIC_AI])
```

No manual `Agent.instrument_all()` call is required by the user.

## Type of Change
- [x] feat - A new feature
- [x] refactor - A code change that neither fixes a bug nor adds a feature
- [x] test - Adding missing tests or correcting existing tests
- [x] build - Changes that affect the build system or external dependencies

## Details

### SDK integration

Adds a new integration enum value:

```py
Integration.PYDANTIC_AI = "pydantic_ai"
```

The registry remains a uniform `InstrumentorEntry` mapping. Instead of adding a separate registry entry type or a one-off branch inside `initialize_integrations()`, this PR adds TraceRoot-owned adapter instrumentors under `traceroot/instrumentation/_instrumentors.py`.

These adapters expose the same `.instrument(tracer_provider=...)` interface as the rest of the registry.

### Adapter instrumentors

Adds adapter instrumentors for integrations that do not exactly match the standard OpenInference lifecycle:
- `PydanticAIInstrumentor`
- `AutogenInstrumentor`

`PydanticAIInstrumentor`:
- Adds OpenInferenceSpanProcessor to the configured tracer provider.
- Calls Agent.instrument_all() so Pydantic-AI emits native OpenTelemetry spans.
- Uses provider-aware idempotence so repeated initialization does not double-register processors on the same provider.
- Allows reinitialization with a new tracer provider.

`AutogenInstrumentor` wraps the existing OpenInference AutoGen instrumentor because that integration does not accept `tracer_provider` in the same way as other instrumentors.

### Registry

The registry still follows the same high-level shape:
```py
InstrumentorEntry(
    package=...,
    module_path=...,
    class_name=...,
)
```
`initialize_integrations()` remains simple:
1. Check that the target package is installed.
2. Import the configured module.
3. Instantiate the configured class.
4. Call .instrument(tracer_provider=tracer_provider).

### Package detection

Adds support for both package names that can provide the pydantic_ai import:
- `pydantic-ai`
- `pydantic-ai-slim`

Only the Pydantic-AI registry entry uses the alternative package detection path.

### Dependency

Adds the OpenInference Pydantic-AI instrumentation dependency:

```
openinference-instrumentation-pydantic-ai>=0.1.15,<1.0
```

### Test plan
- [x] Verify Integration.PYDANTIC_AI enum value exists.
- [x] Verify Pydantic-AI is skipped with a warning when neither pydantic-ai nor pydantic-ai-slim is installed.
- [x] Verify pydantic-ai-slim is accepted as an alternative package.
- [x] Verify PydanticAIInstrumentor adds OpenInferenceSpanProcessor.
- [x] Verify PydanticAIInstrumentor calls Agent.instrument_all().
- [x] Verify repeated initialization with the same provider does not double-register the span processor.
- [x] Verify reinitialization with a new provider still registers the processor.
- [x] Verify Pydantic-AI can be requested alongside existing integrations.
- [x] Run SDK auto-instrumentation tests:

## Checklist
- [x] I have added/updated tests where applicable
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class Pydantic-AI instrumentation to the Python SDK. Enable it with `Integration.PYDANTIC_AI`; it installs the OpenInference span processor and auto-instruments Pydantic-AI without extra calls.

- New Features
  - Added `Integration.PYDANTIC_AI` with an adapter that adds `OpenInferenceSpanProcessor` and calls `pydantic_ai.Agent.instrument_all()`; idempotent.
  - Detects both `pydantic-ai` and `pydantic-ai-slim`, and warns/skips if missing.
  - Works alongside existing integrations.
  - Added dependency: `openinference-instrumentation-pydantic-ai>=0.1.15,<1.0`.

- Refactors
  - Introduced `InstrumentorEntry` for a consistent registry and `.instrument(tracer_provider=...)` flow, with support for `alt_packages`.
  - Added adapter instrumentors: `PydanticAIInstrumentor` and `AutogenInstrumentor` (wraps OpenInference AutoGen to handle providerless API).
  - Simplified `initialize_integrations()` and improved logging.

<sup>Written for commit 641a4233c86c77b25d18cfcb566711eafdfd7e6c. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/120?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

