### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "traceroot"
-version = "0.1.5"
+version = "0.1.6"
 description = "Python SDK for TraceRoot"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
Bumps `traceroot` version to 0.1.6 in `pyproject.toml` to publish the next patch release.

## Test plan
- [ ] CI passes
- [ ] Package builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `traceroot` to version 0.1.6 in `pyproject.toml` to publish the next patch release.

<sup>Written for commit 1065107939e93b6c03dbf2ddeb7c031fccaf3678. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/121?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

