### PR TITLE
fix(sdk): resolve git context from CI/platform environment variables 

### DIFF
--- a/tests/test_git_context.py
+++ b/tests/test_git_context.py
@@ -1,0 +1,429 @@
+"""Tests for git context resolution: harvest_ci_git_context and client integration.
+
+Coverage:
+- GitHub Actions, Vercel, GitLab CI, CircleCI, Bitbucket, Render
+- First-platform-wins precedence (per field)
+- Independent repo / ref resolution
+- Empty environment → both None
+- No fabricated defaults
+- Never raises
+- Warning emitted once when both values remain unresolved
+- Warning suppressed when at least one value resolves
+- Explicit client args bypass CI harvest
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+import traceroot.client as client_module
+from traceroot.git_context import harvest_ci_git_context
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reset_warn_guard() -> None:
+    """Reset the module-level warn-once guard between tests."""
+    client_module._git_context_warning_emitted = False
+
+
+# ---------------------------------------------------------------------------
+# harvest_ci_git_context — platform-specific tests
+# ---------------------------------------------------------------------------
+
+
+class TestHarvestCiGitContextPlatforms:
+    """Each platform correctly populates git_repo and git_ref."""
+
+    def test_github_actions_full(self) -> None:
+        env = {
+            "GITHUB_REPOSITORY": "myorg/myrepo",
+            "GITHUB_SHA": "abc1234567890",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] == "myorg/myrepo"
+        assert result["git_ref"] == "abc1234567890"
+
+    def test_vercel_full(self) -> None:
+        env = {
+            "VERCEL_GIT_REPO_OWNER": "myorg",
+            "VERCEL_GIT_REPO_SLUG": "myrepo",
+            "VERCEL_GIT_COMMIT_SHA": "deadbeef",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] == "myorg/myrepo"
+        assert result["git_ref"] == "deadbeef"
+
+    def test_vercel_missing_owner_gives_none_repo(self) -> None:
+        """Vercel repo requires both owner and slug; only slug → None."""
+        env = {
+            "VERCEL_GIT_REPO_SLUG": "myrepo",
+            "VERCEL_GIT_COMMIT_SHA": "deadbeef",
+        }
+        result = harvest_ci_git_context(env)
+        # repo cannot be formed without the owner
+        assert result["git_repo"] is None
+        assert result["git_ref"] == "deadbeef"
+
+    def test_vercel_missing_slug_gives_none_repo(self) -> None:
+        """Vercel repo requires both owner and slug; only owner → None."""
+        env = {
+            "VERCEL_GIT_REPO_OWNER": "myorg",
+            "VERCEL_GIT_COMMIT_SHA": "deadbeef",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] is None
+        assert result["git_ref"] == "deadbeef"
+
+    def test_gitlab_ci_full(self) -> None:
+        env = {
+            "CI_PROJECT_PATH": "mygroup/myproject",
+            "CI_COMMIT_SHA": "cafebabe",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] == "mygroup/myproject"
+        assert result["git_ref"] == "cafebabe"
+
+    def test_circleci_full(self) -> None:
+        env = {
+            "CIRCLE_PROJECT_USERNAME": "myorg",
+            "CIRCLE_PROJECT_REPONAME": "myrepo",
+            "CIRCLE_SHA1": "feed1234",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] == "myorg/myrepo"
+        assert result["git_ref"] == "feed1234"
+
+    def test_circleci_missing_reponame_gives_none_repo(self) -> None:
+        env = {
+            "CIRCLE_PROJECT_USERNAME": "myorg",
+            "CIRCLE_SHA1": "feed1234",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] is None
+        assert result["git_ref"] == "feed1234"
+
+    def test_bitbucket_full(self) -> None:
+        env = {
+            "BITBUCKET_REPO_FULL_NAME": "myorg/myrepo",
+            "BITBUCKET_COMMIT": "0badc0de",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] == "myorg/myrepo"
+        assert result["git_ref"] == "0badc0de"
+
+    def test_render_ref_only(self) -> None:
+        """Render exposes only a ref; repo must remain None."""
+        env = {
+            "RENDER_GIT_COMMIT": "11223344",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] is None
+        assert result["git_ref"] == "11223344"
+
+
+# ---------------------------------------------------------------------------
+# harvest_ci_git_context — empty environment
+# ---------------------------------------------------------------------------
+
+
+class TestHarvestCiGitContextEmptyEnv:
+    def test_empty_env_returns_none_none(self) -> None:
+        result = harvest_ci_git_context({})
+        assert result == {"git_repo": None, "git_ref": None}
+
+
+# ---------------------------------------------------------------------------
+# harvest_ci_git_context — precedence
+# ---------------------------------------------------------------------------
+
+
+class TestHarvestCiGitContextPrecedence:
+    def test_github_repo_wins_over_gitlab(self) -> None:
+        """GitHub Actions is listed first; its repo var should win."""
+        env = {
+            "GITHUB_REPOSITORY": "gh-org/gh-repo",
+            "GITHUB_SHA": "ghsha",
+            "CI_PROJECT_PATH": "gl-group/gl-project",
+            "CI_COMMIT_SHA": "glsha",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] == "gh-org/gh-repo"
+        assert result["git_ref"] == "ghsha"
+
+    def test_github_ref_wins_over_circleci_ref(self) -> None:
+        env = {
+            "GITHUB_SHA": "github-sha",
+            "CIRCLE_SHA1": "circle-sha",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_ref"] == "github-sha"
+
+    def test_circleci_repo_used_when_github_repo_absent(self) -> None:
+        """Only GitHub SHA is set; repo must fall through to CircleCI."""
+        env = {
+            "GITHUB_SHA": "ghsha",
+            "CIRCLE_PROJECT_USERNAME": "circle-org",
+            "CIRCLE_PROJECT_REPONAME": "circle-repo",
+        }
+        result = harvest_ci_git_context(env)
+        # GitHub has no repo var → CircleCI repo wins
+        assert result["git_repo"] == "circle-org/circle-repo"
+        # GitHub ref wins for ref
+        assert result["git_ref"] == "ghsha"
+
+
+# ---------------------------------------------------------------------------
+# harvest_ci_git_context — independent resolution
+# ---------------------------------------------------------------------------
+
+
+class TestHarvestCiGitContextIndependentResolution:
+    def test_repo_from_github_ref_from_gitlab(self) -> None:
+        """Repo and ref can come from different platforms."""
+        env = {
+            "GITHUB_REPOSITORY": "gh-org/gh-repo",
+            # No GITHUB_SHA → ref must come from GitLab
+            "CI_COMMIT_SHA": "gl-sha",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] == "gh-org/gh-repo"
+        assert result["git_ref"] == "gl-sha"
+
+    def test_only_ref_resolved(self) -> None:
+        """Only ref vars set; repo must be None, ref must be resolved."""
+        env = {"GITHUB_SHA": "sha-only"}
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] is None
+        assert result["git_ref"] == "sha-only"
+
+    def test_only_repo_resolved(self) -> None:
+        """Only repo vars set; git_ref must be None."""
+        env = {"GITHUB_REPOSITORY": "org/repo"}
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] == "org/repo"
+        assert result["git_ref"] is None
+
+
+# ---------------------------------------------------------------------------
+# harvest_ci_git_context — safety
+# ---------------------------------------------------------------------------
+
+
+class TestHarvestCiGitContextSafety:
+    def test_never_raises_on_empty_dict(self) -> None:
+        # Should not raise under any circumstance
+        result = harvest_ci_git_context({})
+        assert isinstance(result, dict)
+
+    def test_never_raises_on_none_env(self) -> None:
+        # Passing None should fall back to os.environ without raising
+        result = harvest_ci_git_context(None)
+        assert isinstance(result, dict)
+        assert "git_repo" in result
+        assert "git_ref" in result
+
+    def test_no_fabricated_default_ref(self) -> None:
+        """Result must never contain a hardcoded fabricated ref."""
+        result = harvest_ci_git_context({})
+        fabricated = {"main", "master", "HEAD", "develop"}
+        assert result["git_ref"] not in fabricated
+
+    def test_no_fabricated_default_repo(self) -> None:
+        result = harvest_ci_git_context({})
+        assert result["git_repo"] is None
+
+    def test_empty_string_treated_as_absent(self) -> None:
+        """Empty-string env vars must not be returned as a resolved value."""
+        env = {
+            "GITHUB_REPOSITORY": "",
+            "GITHUB_SHA": "",
+        }
+        result = harvest_ci_git_context(env)
+        assert result["git_repo"] is None
+        assert result["git_ref"] is None
+
+
+# ---------------------------------------------------------------------------
+# client.py integration — warn-once behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestClientWarnOnce:
+    """Verify the warning behaviour inside TracerootClient.__init__."""
+
+    @pytest.fixture(autouse=True)
+    def reset_warn_flag(self) -> None:
+        """Ensure warn-once guard is reset before every test in this class."""
+        _reset_warn_guard()
+
+    def _make_client(self, git_repo=None, git_ref=None, **kwargs):
+        """Instantiate TracerootClient with subprocess and CI env fully mocked out."""
+        with (
+            # Prevent actual subprocess calls
+            patch("traceroot.git_context.subprocess.check_output", side_effect=OSError),
+            # Serve an empty CI environment
+            patch(
+                "traceroot.git_context.os.environ",
+                new_callable=lambda: (lambda: {}),
+            ) if False else patch("traceroot.client.harvest_ci_git_context", return_value={"git_repo": None, "git_ref": None}),
+            patch("traceroot.client.auto_detect_git_context", return_value={"git_repo": None, "git_ref": None}),
+            # Suppress TRACEROOT env vars
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            from traceroot.client import TracerootClient
+            return TracerootClient(
+                api_key="dummy-key",
+                enabled=False,
+                git_repo=git_repo,
+                git_ref=git_ref,
+                **kwargs,
+            )
+
+    def test_warning_emitted_when_both_unresolved(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="traceroot.client"):
+            self._make_client()
+        assert any("Git context could not be resolved" in r.message for r in caplog.records)
+
+    def test_warning_contains_docs_link(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="traceroot.client"):
+            self._make_client()
+        full_text = " ".join(r.message for r in caplog.records)
+        assert "https://docs.traceroot.ai/tracing/git-context" in full_text
+
+    def test_warning_emitted_only_once(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="traceroot.client"):
+            self._make_client()
+            self._make_client()  # second call must not produce a second warning
+        warn_records = [r for r in caplog.records if "Git context could not be resolved" in r.message]
+        assert len(warn_records) == 1
+
+    def test_no_warning_when_repo_resolved(self, caplog) -> None:
+        with (
+            caplog.at_level(logging.WARNING, logger="traceroot.client"),
+            patch("traceroot.client.harvest_ci_git_context", return_value={"git_repo": None, "git_ref": None}),
+            patch("traceroot.client.auto_detect_git_context", return_value={"git_repo": None, "git_ref": None}),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            from traceroot.client import TracerootClient
+            TracerootClient(api_key="dummy-key", enabled=False, git_repo="org/repo")
+        assert not any("Git context could not be resolved" in r.message for r in caplog.records)
+
+    def test_no_warning_when_ref_resolved(self, caplog) -> None:
+        with (
+            caplog.at_level(logging.WARNING, logger="traceroot.client"),
+            patch("traceroot.client.harvest_ci_git_context", return_value={"git_repo": None, "git_ref": None}),
+            patch("traceroot.client.auto_detect_git_context", return_value={"git_repo": None, "git_ref": None}),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            from traceroot.client import TracerootClient
+            TracerootClient(api_key="dummy-key", enabled=False, git_ref="abc123")
+        assert not any("Git context could not be resolved" in r.message for r in caplog.records)
+
+    def test_no_warning_when_both_resolved_via_ci(self, caplog) -> None:
+        with (
+            caplog.at_level(logging.WARNING, logger="traceroot.client"),
+            patch(
+                "traceroot.client.harvest_ci_git_context",
+                return_value={"git_repo": "ci-org/ci-repo", "git_ref": "ci-sha"},
+            ),
+            patch("traceroot.client.auto_detect_git_context", return_value={"git_repo": None, "git_ref": None}),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            from traceroot.client import TracerootClient
+            TracerootClient(api_key="dummy-key", enabled=False)
+        assert not any("Git context could not be resolved" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# client.py integration — resolution tier ordering
+# ---------------------------------------------------------------------------
+
+
+class TestClientResolutionOrder:
+    """Explicit args and env vars skip lower-priority tiers."""
+
+    @pytest.fixture(autouse=True)
+    def reset_warn_flag(self) -> None:
+        _reset_warn_guard()
+
+    def test_explicit_args_skip_ci_harvest(self) -> None:
+        """When both explicit args are provided, harvest_ci_git_context is not called."""
+        with (
+            patch("traceroot.client.harvest_ci_git_context") as mock_ci,
+            patch("traceroot.client.auto_detect_git_context", return_value={"git_repo": None, "git_ref": None}),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            from traceroot.client import TracerootClient
+            c = TracerootClient(api_key="k", enabled=False, git_repo="org/repo", git_ref="sha")
+        mock_ci.assert_not_called()
+        assert c.git_repo == "org/repo"
+        assert c.git_ref == "sha"
+
+    def test_traceroot_env_vars_skip_ci_harvest(self) -> None:
+        """When TRACEROOT_GIT_REPO and TRACEROOT_GIT_REF are set, CI is not harvested."""
+        with (
+            patch("traceroot.client.harvest_ci_git_context") as mock_ci,
+            patch("traceroot.client.auto_detect_git_context", return_value={"git_repo": None, "git_ref": None}),
+            patch.dict(
+                "os.environ",
+                {"TRACEROOT_GIT_REPO": "env-org/env-repo", "TRACEROOT_GIT_REF": "env-sha"},
+                clear=True,
+            ),
+        ):
+            from traceroot.client import TracerootClient
+            c = TracerootClient(api_key="k", enabled=False)
+        mock_ci.assert_not_called()
+        assert c.git_repo == "env-org/env-repo"
+        assert c.git_ref == "env-sha"
+
+    def test_ci_context_used_when_traceroot_env_absent(self) -> None:
+        """CI tier is consulted when TRACEROOT env vars are not set."""
+        with (
+            patch(
+                "traceroot.client.harvest_ci_git_context",
+                return_value={"git_repo": "ci-org/ci-repo", "git_ref": "ci-sha"},
+            ) as mock_ci,
+            patch("traceroot.client.auto_detect_git_context", return_value={"git_repo": None, "git_ref": None}),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            from traceroot.client import TracerootClient
+            c = TracerootClient(api_key="k", enabled=False)
+        mock_ci.assert_called_once()
+        assert c.git_repo == "ci-org/ci-repo"
+        assert c.git_ref == "ci-sha"
+
+    def test_auto_detect_skipped_when_ci_resolves_both(self) -> None:
+        """auto_detect_git_context is not called when CI provides both values."""
+        with (
+            patch(
+                "traceroot.client.harvest_ci_git_context",
+                return_value={"git_repo": "ci-org/ci-repo", "git_ref": "ci-sha"},
+            ),
+            patch("traceroot.client.auto_detect_git_context") as mock_auto,
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            from traceroot.client import TracerootClient
+            TracerootClient(api_key="k", enabled=False)
+        mock_auto.assert_not_called()
+
+    def test_auto_detect_called_when_ci_only_resolves_repo(self) -> None:
+        """auto_detect_git_context is still consulted when CI resolves only one field."""
+        with (
+            patch(
+                "traceroot.client.harvest_ci_git_context",
+                return_value={"git_repo": "ci-org/ci-repo", "git_ref": None},
+            ),
+            patch(
+                "traceroot.client.auto_detect_git_context",
+                return_value={"git_repo": None, "git_ref": "git-sha"},
+            ) as mock_auto,
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            from traceroot.client import TracerootClient
+            c = TracerootClient(api_key="k", enabled=False)
+        mock_auto.assert_called_once()
+        assert c.git_repo == "ci-org/ci-repo"
+        assert c.git_ref == "git-sha"

--- a/traceroot/client.py
+++ b/traceroot/client.py
@@ -21,11 +21,28 @@ from traceroot.env import (
     TRACEROOT_HOST_URL,
     TRACEROOT_TIMEOUT,
 )
-from traceroot.git_context import auto_detect_git_context
+from traceroot.git_context import auto_detect_git_context, harvest_ci_git_context
 from traceroot.instrumentation.registry import Integration
 from traceroot.transport.span_processor import TracerootSpanProcessor
 
 logger = logging.getLogger(__name__)
+
+# Guard so the "git context unresolved" warning fires at most once per process.
+_git_context_warning_emitted: bool = False
+
+
+def _warn_git_context_unresolved() -> None:
+    """Emit a one-time warning when git context cannot be resolved from any source."""
+    global _git_context_warning_emitted
+    if _git_context_warning_emitted:
+        return
+    _git_context_warning_emitted = True
+    logger.warning(
+        "TraceRoot: Git context could not be resolved. "
+        "Set TRACEROOT_GIT_REPO and TRACEROOT_GIT_REF in production so traces "
+        "can be correlated to source code. "
+        "See https://docs.traceroot.ai/tracing/git-context"
+    )
 
 
 class TracerootClient:
@@ -69,10 +86,13 @@ class TracerootClient:
                 (e.g. ["openai", "langchain"]).
             git_repo: Repository in "owner/repo" format.
                 Falls back to TRACEROOT_GIT_REPO env var,
+                CI/platform env vars (GitHub Actions, Vercel,
+                GitLab CI, CircleCI, Bitbucket, Render),
                 then auto-detected from git remote.
             git_ref: Git reference (commit SHA, tag, branch).
                 Falls back to TRACEROOT_GIT_REF env var,
-                then auto-detected from git HEAD.
+                CI/platform env vars, then auto-detected from
+                git HEAD.
         """
         # Resolve config with env var fallbacks
         self.api_key = api_key or os.environ.get(TRACEROOT_API_KEY, "")
@@ -99,10 +119,34 @@ class TracerootClient:
 
         self._integrations = integrations
 
-        # Resolve git context (explicit > env var > auto-detect)
-        git_ctx = auto_detect_git_context()
-        self.git_repo = git_repo or os.environ.get("TRACEROOT_GIT_REPO") or git_ctx.get("git_repo")
-        self.git_ref = git_ref or os.environ.get("TRACEROOT_GIT_REF") or git_ctx.get("git_ref")
+
+        _env_repo: str | None = os.environ.get("TRACEROOT_GIT_REPO") or None
+        _env_ref: str | None = os.environ.get("TRACEROOT_GIT_REF") or None
+
+        _ci_ctx: dict[str, str | None] = {}
+        if not (git_repo or _env_repo) or not (git_ref or _env_ref):
+            _ci_ctx = harvest_ci_git_context()
+        _git_ctx: dict[str, str | None] = {}
+        _need_repo = not (git_repo or _env_repo or _ci_ctx.get("git_repo"))
+        _need_ref = not (git_ref or _env_ref or _ci_ctx.get("git_ref"))
+        if _need_repo or _need_ref:
+            _git_ctx = auto_detect_git_context()
+
+        self.git_repo = (
+            git_repo
+            or _env_repo
+            or _ci_ctx.get("git_repo")
+            or _git_ctx.get("git_repo")
+        )
+        self.git_ref = (
+            git_ref
+            or _env_ref
+            or _ci_ctx.get("git_ref")
+            or _git_ctx.get("git_ref")
+        )
+
+        if not self.git_repo and not self.git_ref:
+            _warn_git_context_unresolved()
 
         self._enabled = enabled and bool(self.api_key)
         if enabled and not self.api_key:

--- a/traceroot/client.py
+++ b/traceroot/client.py
@@ -3,6 +3,7 @@
 import atexit
 import logging
 import os
+import threading
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -28,15 +29,17 @@ from traceroot.transport.span_processor import TracerootSpanProcessor
 logger = logging.getLogger(__name__)
 
 # Guard so the "git context unresolved" warning fires at most once per process.
+_git_context_warning_lock = threading.Lock()
 _git_context_warning_emitted: bool = False
 
 
 def _warn_git_context_unresolved() -> None:
     """Emit a one-time warning when git context cannot be resolved from any source."""
     global _git_context_warning_emitted
-    if _git_context_warning_emitted:
-        return
-    _git_context_warning_emitted = True
+    with _git_context_warning_lock:
+        if _git_context_warning_emitted:
+            return
+        _git_context_warning_emitted = True
     logger.warning(
         "TraceRoot: Git context could not be resolved. "
         "Set TRACEROOT_GIT_REPO and TRACEROOT_GIT_REF in production so traces "

--- a/traceroot/git_context.py
+++ b/traceroot/git_context.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import os
 import subprocess
+from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +132,139 @@ def auto_detect_git_context() -> dict[str, str | None]:
             timeout=5,
         ).strip()
         result["git_ref"] = ref
+    except Exception:
+        pass
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CI/platform environment variable resolution
+# ---------------------------------------------------------------------------
+
+# Each entry is (platform_name, repo_resolver, ref_resolver).
+# repo_resolver: callable(env) -> str | None
+# ref_resolver:  callable(env) -> str | None
+#
+# Platforms are probed in order; the first non-empty value for each field wins.
+
+def _gh_repo(env: dict[str, str]) -> str | None:
+    return env.get("GITHUB_REPOSITORY") or None
+
+
+def _gh_ref(env: dict[str, str]) -> str | None:
+    return env.get("GITHUB_SHA") or None
+
+
+def _vercel_repo(env: dict[str, str]) -> str | None:
+    owner = env.get("VERCEL_GIT_REPO_OWNER", "")
+    slug = env.get("VERCEL_GIT_REPO_SLUG", "")
+    if owner and slug:
+        return f"{owner}/{slug}"
+    return None
+
+
+def _vercel_ref(env: dict[str, str]) -> str | None:
+    return env.get("VERCEL_GIT_COMMIT_SHA") or None
+
+
+def _gitlab_repo(env: dict[str, str]) -> str | None:
+    return env.get("CI_PROJECT_PATH") or None
+
+
+def _gitlab_ref(env: dict[str, str]) -> str | None:
+    return env.get("CI_COMMIT_SHA") or None
+
+
+def _circleci_repo(env: dict[str, str]) -> str | None:
+    username = env.get("CIRCLE_PROJECT_USERNAME", "")
+    reponame = env.get("CIRCLE_PROJECT_REPONAME", "")
+    if username and reponame:
+        return f"{username}/{reponame}"
+    return None
+
+
+def _circleci_ref(env: dict[str, str]) -> str | None:
+    return env.get("CIRCLE_SHA1") or None
+
+
+def _bitbucket_repo(env: dict[str, str]) -> str | None:
+    return env.get("BITBUCKET_REPO_FULL_NAME") or None
+
+
+def _bitbucket_ref(env: dict[str, str]) -> str | None:
+    return env.get("BITBUCKET_COMMIT") or None
+
+
+def _render_repo(env: dict[str, str]) -> str | None:  # Render does not expose a repo slug
+    return None
+
+
+def _render_ref(env: dict[str, str]) -> str | None:
+    return env.get("RENDER_GIT_COMMIT") or None
+
+
+_CI_PLATFORMS: list[
+    tuple[
+        str,
+        Callable[[dict[str, str]], str | None],
+        Callable[[dict[str, str]], str | None],
+    ]
+] = [
+    ("GitHub Actions",       _gh_repo,        _gh_ref),
+    ("Vercel",               _vercel_repo,    _vercel_ref),
+    ("GitLab CI",            _gitlab_repo,    _gitlab_ref),
+    ("CircleCI",             _circleci_repo,  _circleci_ref),
+    ("Bitbucket Pipelines",  _bitbucket_repo, _bitbucket_ref),
+    ("Render",               _render_repo,    _render_ref),
+]
+
+
+def harvest_ci_git_context(
+    env: dict[str, str] | None = None,
+) -> dict[str, str | None]:
+    """Harvest git_repo and git_ref from CI/platform environment variables.
+
+    Checks platforms in order (first-platform-wins per field)::
+
+        GitHub Actions → Vercel → GitLab CI → CircleCI
+        → Bitbucket Pipelines → Render
+
+    ``git_repo`` and ``git_ref`` are resolved **independently**.  If platform A
+    provides only a ref and platform B provides only a repo, both values are
+    used regardless of the platform order.
+
+    Args:
+        env: Environment mapping to probe.  Defaults to ``os.environ``.
+             Pass a plain ``dict`` in tests to avoid touching the real
+             process environment.
+
+    Returns:
+        ``dict`` with ``"git_repo"`` and ``"git_ref"`` keys.  Either value
+        may be ``None`` when it cannot be resolved.  Never raises.
+    """
+    if env is None:
+        env = dict(os.environ)
+
+    result: dict[str, str | None] = {"git_repo": None, "git_ref": None}
+
+    try:
+        for _platform, repo_fn, ref_fn in _CI_PLATFORMS:
+            if result["git_repo"] is None:
+                try:
+                    result["git_repo"] = repo_fn(env)
+                except Exception:
+                    pass
+
+            if result["git_ref"] is None:
+                try:
+                    result["git_ref"] = ref_fn(env)
+                except Exception:
+                    pass
+
+            # Short-circuit once both fields are satisfied
+            if result["git_repo"] and result["git_ref"]:
+                break
     except Exception:
         pass
 

--- a/traceroot/git_context.py
+++ b/traceroot/git_context.py
@@ -137,17 +137,6 @@ def auto_detect_git_context() -> dict[str, str | None]:
 
     return result
 
-
-# ---------------------------------------------------------------------------
-# CI/platform environment variable resolution
-# ---------------------------------------------------------------------------
-
-# Each entry is (platform_name, repo_resolver, ref_resolver).
-# repo_resolver: callable(env) -> str | None
-# ref_resolver:  callable(env) -> str | None
-#
-# Platforms are probed in order; the first non-empty value for each field wins.
-
 def _gh_repo(env: dict[str, str]) -> str | None:
     return env.get("GITHUB_REPOSITORY") or None
 


### PR DESCRIPTION
fixes # https://github.com/traceroot-ai/traceroot/issues/1024
Summary

This PR fixes an issue where the Python SDK could not resolve git_repo and git_ref in production environments that do not include a .git directory or git binary.
A new CI/CD environment variable resolution layer has been added before local git auto-detection.

Changes

* Added harvest_ci_git_context(env=None) for CI/CD platform metadata.
* Wired resolution as:
    explicit args -> TRACEROOT_GIT_* -> CI/platform env -> local git -> warn once
* Added warn-once behavior when git context remains unresolved.
* Kept unresolved fields omitted instead of fabricating values.
* Added dedicated tests covering CI platform resolution and warning behavior.

## Checklist

- [x] I have added/updated tests where applicable
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve `git_repo` and `git_ref` in CI/CD by harvesting platform environment variables, so the Python SDK works in production without a `.git` directory or `git` binary. Adds a one-time, thread-safe warning if both values remain unresolved, and avoids fabricating defaults.

- **Bug Fixes**
  - Added CI/platform env harvesting (`harvest_ci_git_context`) for GitHub Actions, Vercel, GitLab CI, CircleCI, Bitbucket, and Render.
  - Per-field resolution order: explicit args → `TRACEROOT_GIT_*` → CI/platform env → local git; unresolved fields remain None.
  - Emits a warning with a docs link only when both values are unresolved, guarded to fire once per process.
  - Made the warning guard thread-safe to prevent duplicate logs in multi-threaded apps.

<sup>Written for commit 9fd655c282236b9bcf931cb6e564fab7b03f613c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

