### PR TITLE
Production-grade git context: CI/.git resolution, warn-on-missing, git on all spans

### DIFF
--- a/tests/test_git_context.py
+++ b/tests/test_git_context.py
@@ -45,6 +45,19 @@ def test_files_ref_based_head(tmp_path):
     assert r["git_ref"] == "1" * 40
 
 
+def test_files_packed_refs(tmp_path):
+    # HEAD points at a branch whose loose ref file is absent (gc'd / fresh clone);
+    # the SHA lives in packed-refs.
+    git_dir = tmp_path / ".git"
+    _write(git_dir / "HEAD", "ref: refs/heads/main\n")
+    _write(
+        git_dir / "packed-refs",
+        "# pack-refs with: peeled fully-peeled sorted\n" + "2" * 40 + " refs/heads/main\n",
+    )
+    r = git_context_from_files(str(tmp_path))
+    assert r["git_ref"] == "2" * 40
+
+
 def test_files_https_url(tmp_path):
     git_dir = tmp_path / ".git"
     _write(git_dir / "config", '[remote "origin"]\n\turl = https://github.com/acme/web.git\n')
@@ -88,4 +101,27 @@ def test_client_warns_when_git_unresolved(monkeypatch, caplog):
     monkeypatch.setattr(client_mod.TracerootClient, "_initialize", lambda self: None)
     with caplog.at_level(logging.WARNING):
         client_mod.TracerootClient(api_key="test", git_repo=None, git_ref=None)
+    assert any("git context incomplete" in r.message for r in caplog.records)
+
+
+def test_client_treats_empty_git_env_as_unset(monkeypatch, caplog):
+    # Empty TRACEROOT_GIT_* must behave like unset: fall through and warn,
+    # never store "" as a resolved value.
+    monkeypatch.setenv("TRACEROOT_GIT_REPO", "")
+    monkeypatch.setenv("TRACEROOT_GIT_REF", "")
+    for v in ("GITHUB_REPOSITORY", "GITHUB_SHA"):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setattr(
+        client_mod, "auto_detect_git_context", lambda: {"git_repo": None, "git_ref": None}
+    )
+    monkeypatch.setattr(
+        client_mod, "harvest_ci_git_context", lambda: {"git_repo": None, "git_ref": None}
+    )
+    monkeypatch.setattr(
+        client_mod, "git_context_from_files", lambda: {"git_repo": None, "git_ref": None}
+    )
+    monkeypatch.setattr(client_mod.TracerootClient, "_initialize", lambda self: None)
+    with caplog.at_level(logging.WARNING):
+        c = client_mod.TracerootClient(api_key="test", git_repo=None, git_ref=None)
+    assert c.git_repo is None and c.git_ref is None
     assert any("git context incomplete" in r.message for r in caplog.records)

--- a/tests/test_git_context.py
+++ b/tests/test_git_context.py
@@ -1,0 +1,91 @@
+"""Tests for CI/platform git-context harvesting."""
+
+import logging
+
+import traceroot.client as client_mod
+from traceroot.git_context import git_context_from_files, harvest_ci_git_context
+
+
+def test_github_actions():
+    r = harvest_ci_git_context({"GITHUB_REPOSITORY": "acme/web", "GITHUB_SHA": "a" * 40})
+    assert r == {"git_repo": "acme/web", "git_ref": "a" * 40}
+
+
+def test_empty_env():
+    assert harvest_ci_git_context({}) == {"git_repo": None, "git_ref": None}
+
+
+def test_empty_string_github_treated_as_absent():
+    r = harvest_ci_git_context({"GITHUB_REPOSITORY": ""})
+    assert r["git_repo"] is None
+
+
+# ---------------------------------------------------------------------------
+# git_context_from_files tests
+# ---------------------------------------------------------------------------
+def _write(p, content):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def test_files_detached_head_and_git_at_url(tmp_path):
+    git_dir = tmp_path / ".git"
+    _write(git_dir / "config", '[remote "origin"]\n\turl = git@github.com:acme/web.git\n')
+    _write(git_dir / "HEAD", "f" * 40 + "\n")
+    r = git_context_from_files(str(tmp_path))
+    assert r["git_repo"] == "acme/web"
+    assert r["git_ref"] == "f" * 40
+
+
+def test_files_ref_based_head(tmp_path):
+    git_dir = tmp_path / ".git"
+    _write(git_dir / "HEAD", "ref: refs/heads/main\n")
+    _write(git_dir / "refs" / "heads" / "main", "1" * 40 + "\n")
+    r = git_context_from_files(str(tmp_path))
+    assert r["git_ref"] == "1" * 40
+
+
+def test_files_https_url(tmp_path):
+    git_dir = tmp_path / ".git"
+    _write(git_dir / "config", '[remote "origin"]\n\turl = https://github.com/acme/web.git\n')
+    r = git_context_from_files(str(tmp_path))
+    assert r["git_repo"] == "acme/web"
+
+
+def test_files_prefers_url_over_pushurl(tmp_path):
+    git_dir = tmp_path / ".git"
+    _write(
+        git_dir / "config",
+        '[remote "origin"]\n\tpushurl = git@github.com:acme/push-mirror.git\n\turl = git@github.com:acme/web.git\n',
+    )
+    r = git_context_from_files(str(tmp_path))
+    assert r["git_repo"] == "acme/web"
+
+
+def test_files_missing_git_dir(tmp_path):
+    r = git_context_from_files(str(tmp_path))
+    assert r == {"git_repo": None, "git_ref": None}
+
+
+def test_client_warns_when_git_unresolved(monkeypatch, caplog):
+    for v in (
+        "TRACEROOT_GIT_REPO",
+        "TRACEROOT_GIT_REF",
+        "GITHUB_REPOSITORY",
+        "GITHUB_SHA",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setattr(
+        client_mod, "auto_detect_git_context", lambda: {"git_repo": None, "git_ref": None}
+    )
+    monkeypatch.setattr(
+        client_mod, "harvest_ci_git_context", lambda: {"git_repo": None, "git_ref": None}
+    )
+    monkeypatch.setattr(
+        client_mod, "git_context_from_files", lambda: {"git_repo": None, "git_ref": None}
+    )
+    # Disable OTel initialization to avoid corrupting the shared global TracerProvider
+    monkeypatch.setattr(client_mod.TracerootClient, "_initialize", lambda self: None)
+    with caplog.at_level(logging.WARNING):
+        client_mod.TracerootClient(api_key="test", git_repo=None, git_ref=None)
+    assert any("git context incomplete" in r.message for r in caplog.records)

--- a/tests/test_span_processor_path.py
+++ b/tests/test_span_processor_path.py
@@ -352,3 +352,98 @@ def test_map_stays_empty_when_only_non_recording_spans_processed(proc_setup):
 
     assert processor._ids_path_by_span_id == {}
     assert processor._name_path_by_span_id == {}
+
+
+# ── Git context attributes ─────────────────────────────────────────────────────
+
+
+def test_git_attrs_on_all_spans():
+    """git_repo and git_ref passed to the processor are stamped on every span."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    proc = TracerootSpanProcessor(
+        api_key="test",
+        host_url="http://localhost:9999",
+        git_repo="acme/web",
+        git_ref="a" * 40,
+    )
+    provider = TracerProvider()
+    provider.add_span_processor(proc)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    with tracer.start_as_current_span("plain-span"):
+        pass
+    provider.force_flush()
+    span = next(s for s in exporter.get_finished_spans() if s.name == "plain-span")
+    assert span.attributes.get("traceroot.git.repo") == "acme/web"
+    assert span.attributes.get("traceroot.git.ref") == "a" * 40
+
+
+def test_git_attrs_absent_when_not_configured():
+    """No git attributes are stamped when git_repo/git_ref are not provided."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    proc = TracerootSpanProcessor(api_key="test", host_url="http://localhost:9999")
+    provider = TracerProvider()
+    provider.add_span_processor(proc)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    with tracer.start_as_current_span("plain-span"):
+        pass
+    provider.force_flush()
+    span = next(s for s in exporter.get_finished_spans() if s.name == "plain-span")
+    assert span.attributes.get("traceroot.git.repo") is None
+    assert span.attributes.get("traceroot.git.ref") is None
+
+
+def test_git_attrs_stamped_independently():
+    """repo and ref stamp independently — repo set, ref absent stamps only repo."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    proc = TracerootSpanProcessor(
+        api_key="test", host_url="http://localhost:9999", git_repo="acme/web"
+    )
+    provider = TracerProvider()
+    provider.add_span_processor(proc)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    with tracer.start_as_current_span("plain-span"):
+        pass
+    provider.force_flush()
+    span = next(s for s in exporter.get_finished_spans() if s.name == "plain-span")
+    assert span.attributes.get("traceroot.git.repo") == "acme/web"
+    assert span.attributes.get("traceroot.git.ref") is None
+
+
+def test_git_attrs_on_child_spans():
+    """git_repo and git_ref are stamped on child spans too."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    proc = TracerootSpanProcessor(
+        api_key="test",
+        host_url="http://localhost:9999",
+        git_repo="org/repo",
+        git_ref="deadbeef" * 5,
+    )
+    provider = TracerProvider()
+    provider.add_span_processor(proc)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    with tracer.start_as_current_span("root"), tracer.start_as_current_span("child"):
+        pass
+    provider.force_flush()
+    child = next(s for s in exporter.get_finished_spans() if s.name == "child")
+    assert child.attributes.get("traceroot.git.repo") == "org/repo"
+    assert child.attributes.get("traceroot.git.ref") == "deadbeef" * 5

--- a/traceroot/client.py
+++ b/traceroot/client.py
@@ -106,8 +106,10 @@ class TracerootClient:
         self._integrations = integrations
 
         # Resolve git context: explicit > env > CI vars > auto-detect.
-        self.git_repo = git_repo or os.environ.get(TRACEROOT_GIT_REPO)
-        self.git_ref = git_ref or os.environ.get(TRACEROOT_GIT_REF)
+        # `or None` so an empty env var ("") is treated as unset — otherwise it
+        # would block fallback detection and suppress the missing-context warning.
+        self.git_repo = git_repo or os.environ.get(TRACEROOT_GIT_REPO) or None
+        self.git_ref = git_ref or os.environ.get(TRACEROOT_GIT_REF) or None
 
         if self.git_repo is None or self.git_ref is None:
             ci = harvest_ci_git_context()

--- a/traceroot/client.py
+++ b/traceroot/client.py
@@ -18,10 +18,16 @@ from traceroot.env import (
     TRACEROOT_ENABLED,
     TRACEROOT_FLUSH_AT,
     TRACEROOT_FLUSH_INTERVAL,
+    TRACEROOT_GIT_REF,
+    TRACEROOT_GIT_REPO,
     TRACEROOT_HOST_URL,
     TRACEROOT_TIMEOUT,
 )
-from traceroot.git_context import auto_detect_git_context
+from traceroot.git_context import (
+    auto_detect_git_context,
+    git_context_from_files,
+    harvest_ci_git_context,
+)
 from traceroot.instrumentation.registry import Integration
 from traceroot.transport.span_processor import TracerootSpanProcessor
 
@@ -99,10 +105,34 @@ class TracerootClient:
 
         self._integrations = integrations
 
-        # Resolve git context (explicit > env var > auto-detect)
-        git_ctx = auto_detect_git_context()
-        self.git_repo = git_repo or os.environ.get("TRACEROOT_GIT_REPO") or git_ctx.get("git_repo")
-        self.git_ref = git_ref or os.environ.get("TRACEROOT_GIT_REF") or git_ctx.get("git_ref")
+        # Resolve git context: explicit > env > CI vars > auto-detect.
+        self.git_repo = git_repo or os.environ.get(TRACEROOT_GIT_REPO)
+        self.git_ref = git_ref or os.environ.get(TRACEROOT_GIT_REF)
+
+        if self.git_repo is None or self.git_ref is None:
+            ci = harvest_ci_git_context()
+            self.git_repo = self.git_repo or ci["git_repo"]
+            self.git_ref = self.git_ref or ci["git_ref"]
+
+        if self.git_repo is None or self.git_ref is None:
+            from_files = git_context_from_files()
+            self.git_repo = self.git_repo or from_files["git_repo"]
+            self.git_ref = self.git_ref or from_files["git_ref"]
+
+        if self.git_repo is None or self.git_ref is None:
+            auto = auto_detect_git_context()
+            self.git_repo = self.git_repo or auto.get("git_repo")
+            self.git_ref = self.git_ref or auto.get("git_ref")
+
+        if self.git_repo is None or self.git_ref is None:
+            logger.warning(
+                "TraceRoot: git context incomplete (repo=%s, ref=%s). The AI "
+                "agent needs both to correlate traces to source. Set "
+                "TRACEROOT_GIT_REPO / TRACEROOT_GIT_REF — see "
+                "https://docs.traceroot.ai/tracing/git-context",
+                self.git_repo or "unset",
+                self.git_ref or "unset",
+            )
 
         self._enabled = enabled and bool(self.api_key)
         if enabled and not self.api_key:
@@ -131,6 +161,8 @@ class TracerootClient:
             flush_at=self.batch_size,
             flush_interval=self.flush_interval,
             timeout=self.timeout,
+            git_repo=self.git_repo,
+            git_ref=self.git_ref,
         )
 
         # Create and configure TracerProvider

--- a/traceroot/decorators.py
+++ b/traceroot/decorators.py
@@ -109,7 +109,7 @@ def observe(
                     session_id,
                     user_id,
                 )
-                _set_source_and_git_context(span)
+                _set_source_context(span)
                 gen = func(*args, **kwargs)
                 async for item in _wrap_async_generator(gen, span, capture_output):
                     yield item
@@ -135,7 +135,7 @@ def observe(
                     session_id,
                     user_id,
                 )
-                _set_source_and_git_context(span)
+                _set_source_context(span)
                 gen = func(*args, **kwargs)
                 yield from _wrap_sync_generator(gen, span, capture_output)
 
@@ -160,7 +160,7 @@ def observe(
                         session_id,
                         user_id,
                     )
-                    _set_source_and_git_context(span)
+                    _set_source_context(span)
 
                     try:
                         result = await func(*args, **kwargs)
@@ -193,7 +193,7 @@ def observe(
                         session_id,
                         user_id,
                     )
-                    _set_source_and_git_context(span)
+                    _set_source_context(span)
 
                     try:
                         result = func(*args, **kwargs)
@@ -254,8 +254,13 @@ async def _wrap_async_generator(
         span.end()
 
 
-def _set_source_and_git_context(span: trace.Span) -> None:
-    """Set source location and git context attributes on span."""
+def _set_source_context(span: trace.Span) -> None:
+    """Set source location attributes on span.
+
+    Git repo/ref are now stamped on every recording span by the
+    TracerootSpanProcessor (constructor-injected), so this function only
+    handles the per-call source file/line/function context.
+    """
     source = capture_source_location()
     if source.get("git_source_file"):
         span.set_attribute(SpanAttributes.GIT_SOURCE_FILE, source["git_source_file"])
@@ -263,14 +268,6 @@ def _set_source_and_git_context(span: trace.Span) -> None:
         span.set_attribute(SpanAttributes.GIT_SOURCE_LINE, source["git_source_line"])
     if source.get("git_source_function"):
         span.set_attribute(SpanAttributes.GIT_SOURCE_FUNCTION, source["git_source_function"])
-
-    from traceroot import get_client
-
-    client = get_client()
-    if client and client.git_repo:
-        span.set_attribute(SpanAttributes.GIT_REPO, client.git_repo)
-    if client and client.git_ref:
-        span.set_attribute(SpanAttributes.GIT_REF, client.git_ref)
 
 
 def _set_span_attributes(

--- a/traceroot/env.py
+++ b/traceroot/env.py
@@ -153,3 +153,19 @@ Auto-detected from git HEAD if not set.
 
 **Example:** ``v1.2.3`` or ``abc123def``
 """
+
+# =============================================================================
+# CI Platform — GitHub Actions
+# =============================================================================
+
+GITHUB_REPOSITORY = "GITHUB_REPOSITORY"
+"""
+GitHub Actions: repository in ``owner/repo`` form. Used for CI git-context
+harvesting.
+"""
+
+GITHUB_SHA = "GITHUB_SHA"
+"""
+GitHub Actions: commit SHA of the checked-out code. Used for CI git-context
+harvesting.
+"""

--- a/traceroot/git_context.py
+++ b/traceroot/git_context.py
@@ -142,10 +142,29 @@ def git_context_from_files(cwd: str | None = None) -> dict[str, str | None]:
         else:
             rm = re.match(r"ref:\s+(\S+)", head)
             if rm:
-                with open(os.path.join(git_dir, rm.group(1)), encoding="utf-8") as f:
-                    ref_content = f.read().strip()
-                if _SHA_RE.match(ref_content):
-                    result["git_ref"] = ref_content
+                ref_path = rm.group(1)  # e.g. refs/heads/main
+                try:
+                    with open(os.path.join(git_dir, ref_path), encoding="utf-8") as f:
+                        loose = f.read().strip()
+                    if _SHA_RE.match(loose):
+                        result["git_ref"] = loose
+                except OSError:
+                    pass  # loose ref missing — the ref may be packed
+                if result["git_ref"] is None:
+                    try:
+                        # Packed refs (after `git gc` / fresh clone).
+                        with open(os.path.join(git_dir, "packed-refs"), encoding="utf-8") as f:
+                            packed = f.read()
+                        for line in packed.splitlines():
+                            if not line or line[0] in "#^":
+                                continue
+                            # OIDs are exactly 40 (SHA-1) or 64 (SHA-256) hex.
+                            m = re.match(r"^([0-9a-f]{40}|[0-9a-f]{64})\s+(.+)$", line)
+                            if m and m.group(2) == ref_path:
+                                result["git_ref"] = m.group(1)
+                                break
+                    except OSError:
+                        pass
     except OSError:
         pass
 

--- a/traceroot/git_context.py
+++ b/traceroot/git_context.py
@@ -3,12 +3,24 @@
 import inspect
 import logging
 import os
+import re
 import subprocess
+from collections.abc import Mapping
+
+from traceroot.env import GITHUB_REPOSITORY, GITHUB_SHA
 
 logger = logging.getLogger(__name__)
 
 # Directory of this package — used to identify SDK-internal frames
 _PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Regex to parse owner/repo from GitHub remote URLs.
+# Handles: https://github.com/o/r.git, git@github.com:o/r.git,
+# ssh://git@github.com/o/r.git
+_REPO_URL_RE = re.compile(r"(?:https?://|ssh://git@|git@)github\.com[:/](.+?)(?:\.git)?$")
+
+# Regex to validate a 40-char hex SHA
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 # Additional library paths to skip when walking the call stack
 _SKIP_LIBRARIES = [
@@ -92,6 +104,54 @@ def _relative_path(filepath: str) -> str:
     return filepath
 
 
+def git_context_from_files(cwd: str | None = None) -> dict[str, str | None]:
+    """Read git context directly from ``.git`` files (no ``git`` subprocess).
+
+    Works in containers that ship a ``.git`` dir but no ``git`` binary.
+    Only inspects ``<cwd>/.git`` (does not walk parent directories).
+    """
+    base = cwd if cwd is not None else os.getcwd()
+    git_dir = os.path.join(base, ".git")
+    result: dict[str, str | None] = {"git_repo": None, "git_ref": None}
+
+    try:
+        with open(os.path.join(git_dir, "config"), encoding="utf-8") as f:
+            config = f.read()
+        seen_origin = False
+        for line in config.splitlines():
+            if re.match(r'^\[remote "origin"\]', line):
+                seen_origin = True
+                continue
+            if seen_origin and line.startswith("["):
+                break
+            if seen_origin:
+                m = re.search(r"\burl\s*=\s*(.+)$", line)
+                if m:
+                    rm = _REPO_URL_RE.match(m.group(1).strip())
+                    if rm:
+                        result["git_repo"] = rm.group(1).rstrip("/")
+                    break
+    except OSError:
+        pass
+
+    try:
+        with open(os.path.join(git_dir, "HEAD"), encoding="utf-8") as f:
+            head = f.read().strip()
+        if _SHA_RE.match(head):
+            result["git_ref"] = head
+        else:
+            rm = re.match(r"ref:\s+(\S+)", head)
+            if rm:
+                with open(os.path.join(git_dir, rm.group(1)), encoding="utf-8") as f:
+                    ref_content = f.read().strip()
+                if _SHA_RE.match(ref_content):
+                    result["git_ref"] = ref_content
+    except OSError:
+        pass
+
+    return result
+
+
 def auto_detect_git_context() -> dict[str, str | None]:
     """Auto-detect git_repo and git_ref from local git repo.
 
@@ -108,15 +168,8 @@ def auto_detect_git_context() -> dict[str, str | None]:
             timeout=5,
         ).strip()
 
-        # Parse owner/repo from URL
-        # Handles: https://github.com/o/r.git,
-        # git@github.com:o/r.git, ssh://git@github.com/o/r.git
-        import re
-
-        match = re.match(
-            r"(?:https?://|ssh://git@|git@)github\.com[:/](.+?)(?:\.git)?$",
-            remote,
-        )
+        # Parse owner/repo from URL using shared regex
+        match = _REPO_URL_RE.match(remote)
         if match:
             result["git_repo"] = match.group(1).rstrip("/")
     except Exception:
@@ -135,3 +188,18 @@ def auto_detect_git_context() -> dict[str, str | None]:
         pass
 
     return result
+
+
+def harvest_ci_git_context(
+    env: Mapping[str, str] | None = None,
+) -> dict[str, str | None]:
+    """Resolve git context from GitHub Actions environment variables —
+    ``GITHUB_REPOSITORY`` (owner/repo) and ``GITHUB_SHA``.
+
+    repo and ref resolve independently (a build may provide one, not both).
+    """
+    e = os.environ if env is None else env
+    return {
+        "git_repo": e.get(GITHUB_REPOSITORY) or None,
+        "git_ref": e.get(GITHUB_SHA) or None,
+    }

--- a/traceroot/transport/span_processor.py
+++ b/traceroot/transport/span_processor.py
@@ -60,6 +60,8 @@ class TracerootSpanProcessor(BatchSpanProcessor):
         flush_at: int | None = None,
         flush_interval: float | None = None,
         timeout: float | None = None,
+        git_repo: str | None = None,
+        git_ref: str | None = None,
     ):
         """Initialize the span processor.
 
@@ -73,6 +75,10 @@ class TracerootSpanProcessor(BatchSpanProcessor):
                 TRACEROOT_FLUSH_INTERVAL env var, then DEFAULT_FLUSH_INTERVAL.
             timeout: HTTP request timeout in seconds. Falls back to
                 TRACEROOT_TIMEOUT env var, then DEFAULT_TIMEOUT.
+            git_repo: Repository in "owner/repo" format. When provided, stamped
+                as ``traceroot.git.repo`` on every recording span.
+            git_ref: Git reference (commit SHA, tag, branch). When provided,
+                stamped as ``traceroot.git.ref`` on every recording span.
         """
         # Resolve flush_at with env var fallback
         if flush_at is None:
@@ -115,6 +121,8 @@ class TracerootSpanProcessor(BatchSpanProcessor):
 
         self._flush_at = flush_at
         self._flush_interval = flush_interval
+        self._git_repo = git_repo
+        self._git_ref = git_ref
         self._paths_lock = threading.RLock()
         # Bounded OrderedDict: evicts oldest entry when capacity is exceeded,
         # eliminating the on_end race where a parent was removed before a
@@ -126,6 +134,10 @@ class TracerootSpanProcessor(BatchSpanProcessor):
         if span.is_recording():
             span.set_attribute("traceroot.sdk.name", SDK_NAME)
             span.set_attribute("traceroot.sdk.version", SDK_VERSION)
+            if self._git_repo:
+                span.set_attribute("traceroot.git.repo", self._git_repo)
+            if self._git_ref:
+                span.set_attribute("traceroot.git.ref", self._git_ref)
 
             try:
                 # span.parent is the SpanContext of the parent (set by the SDK at


### PR DESCRIPTION
## What

Two related fixes so `git_repo` / `git_ref` populate reliably in production **and** on every span (bringing the Python SDK in line with TypeScript).

**1. Layered resolution** (first hit wins, cached):
1. explicit init args (`git_repo`/`git_ref`)
2. `TRACEROOT_GIT_REPO` / `TRACEROOT_GIT_REF`
3. GitHub Actions env (`GITHUB_REPOSITORY` / `GITHUB_SHA`)
4. `.git` files read directly (no `git` binary)
5. `git` subprocess (dev last resort)
6. warn once if still unresolved — never fabricate

**2. Git on all spans.** Stamping moved from the `@observe` decorator into the span processor's `on_start` (via constructor injection), so **auto-instrumented** spans (OpenAI, LangChain, …) now carry git context — previously only `@observe`-decorated spans did. The decorator now sets source file/line/function only (renamed `_set_source_context`).

## Changes
- `traceroot/git_context.py` — `harvest_ci_git_context`, `git_context_from_files`, shared regexes
- `traceroot/client.py` — resolution ladder + warn-once; pass git to processor
- `traceroot/env.py` — centralized `GITHUB_*` var names
- `traceroot/transport/span_processor.py` — stamp git in `on_start`
- `traceroot/decorators.py` — drop repo/ref stamping; rename `_set_source_context`
- tests — harvest, file-read, warn-once, git-on-all-spans

## Testing
- Full suite: 165 passing; `ruff check` + `ruff format --check` clean
- E2E on staging (this build): build-time injection, CI harvest, `.git` auto-detect, unresolved→warn; plus a **real OpenAI agent** whose auto-instrumented `ChatCompletion` spans carry git context in ClickHouse

## Issues
Refs traceroot-ai/traceroot#1024, traceroot-ai/traceroot#1026, traceroot-ai/traceroot#1027 (cross-repo — close on merge). Part of epic traceroot-ai/traceroot#1028.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Production-grade git context: reliably resolve `git_repo`/`git_ref` and stamp them on every span, including auto-instrumented spans. Adds CI and `.git` file detection with warn-on-missing, reads `.git/packed-refs`, and treats empty `TRACEROOT_GIT_*` as unset.

- **New Features**
  - Layered resolution: init args → `TRACEROOT_GIT_REPO`/`TRACEROOT_GIT_REF` → GitHub Actions (`GITHUB_REPOSITORY`/`GITHUB_SHA`) → `.git` files (no `git` binary) → `git` subprocess.
  - Git context stamped in the span processor `on_start`, so all spans carry `traceroot.git.repo` and `traceroot.git.ref`. Decorator now only sets source file/line/function via `_set_source_context`.
  - One-time warning when repo or ref is missing. Centralized env var names and helpers for CI/file-based harvesting.

- **Bug Fixes**
  - `.git/packed-refs` fallback when loose ref is absent; supports 40 or 64 hex OIDs.
  - Empty `TRACEROOT_GIT_REPO`/`TRACEROOT_GIT_REF` are treated as unset to allow fallback detection and proper warnings.

<sup>Written for commit 7362edbbbb701ed66fd96f9bb149da43ecf64dc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

