### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "traceroot"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python SDK for TraceRoot"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
Bumps `traceroot` version to 0.1.7 in `pyproject.toml` to publish the next patch release.

## Test plan
- [ ] CI passes
- [ ] Package builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `traceroot` to version 0.1.7 in `pyproject.toml` to publish the next patch release. No functional changes.

<sup>Written for commit 235ed4459f3ff257cd1fdd7c7e766570832f47b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

