### PR TITLE
feat: add in-house Claude Agent SDK instrumentation

### DIFF
--- a/tests/test_claude_agent_sdk.py
+++ b/tests/test_claude_agent_sdk.py
@@ -1,0 +1,367 @@
+"""Tests for the in-house Claude Agent SDK instrumentation.
+
+Focus areas:
+  1. Token/cost: authoritative token usage comes from the ResultMessage and lands
+     on an LLM span (not the parent agent/query span); cost is not computed here.
+  2. Timeline: subagent task spans are created from task system messages
+     (including TaskProgress, not only TaskStarted) and parents cover children.
+
+Messages are lightweight stand-ins whose class names match what the real SDK
+emits (the instrumentor dispatches on ``type(message).__name__``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from traceroot.instrumentation.claude_agent_sdk import wrap_query
+
+LLM_COMPLETION = "llm.token_count.completion"
+LLM_PROMPT = "llm.token_count.prompt"
+SPAN_KIND = "openinference.span.kind"
+
+
+# --- synthetic message / block stand-ins -----------------------------------
+
+
+class TextBlock:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class ToolUseBlock:
+    def __init__(self, id: str, name: str, input=None):
+        self.id = id
+        self.name = name
+        self.input = input or {}
+
+
+class ToolResultBlock:
+    def __init__(self, tool_use_id: str, content=None, is_error: bool = False):
+        self.tool_use_id = tool_use_id
+        self.content = content
+        self.is_error = is_error
+
+
+class AssistantMessage:
+    def __init__(self, content, model=None, message_id=None, usage=None, parent_tool_use_id=None):
+        self.content = content
+        self.model = model
+        self.message_id = message_id
+        self.usage = usage
+        self.parent_tool_use_id = parent_tool_use_id
+
+
+class UserMessage:
+    def __init__(self, content, parent_tool_use_id=None):
+        self.content = content
+        self.parent_tool_use_id = parent_tool_use_id
+
+
+class ResultMessage:
+    def __init__(
+        self, result=None, usage=None, total_cost_usd=None, num_turns=None, session_id=None
+    ):
+        self.result = result
+        self.usage = usage
+        self.total_cost_usd = total_cost_usd
+        self.num_turns = num_turns
+        self.session_id = session_id
+
+
+class TaskStartedMessage:
+    def __init__(self, task_id, description=None, tool_use_id=None, task_type=None):
+        self.task_id = task_id
+        self.description = description
+        self.tool_use_id = tool_use_id
+        self.task_type = task_type
+
+
+class TaskProgressMessage:
+    def __init__(self, task_id, description=None, usage=None, tool_use_id=None):
+        self.task_id = task_id
+        self.description = description
+        self.usage = usage
+        self.tool_use_id = tool_use_id
+
+
+class TaskNotificationMessage:
+    def __init__(self, task_id, tool_use_id=None, usage=None):
+        self.task_id = task_id
+        self.tool_use_id = tool_use_id
+        self.usage = usage
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _provider():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+async def _run(provider, messages):
+    async def fake_query(*, prompt, options=None, transport=None):
+        for m in messages:
+            yield m
+
+    wrapped = wrap_query(fake_query, provider)
+    async for _ in wrapped(prompt="hello", options=None):
+        pass
+
+
+def _llm_spans(exporter):
+    return [s for s in exporter.get_finished_spans() if s.name == "anthropic.messages.create"]
+
+
+# --- Step 1: token / cost ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_output_tokens_reconciled_to_result_message():
+    """Total completion tokens on LLM spans must equal the ResultMessage total,
+    not the tiny per-streamed-message values."""
+    provider, exporter = _provider()
+    messages = [
+        AssistantMessage(
+            [TextBlock("thinking")],
+            model="claude-sonnet-4",
+            message_id="m1",
+            usage={"input_tokens": 10, "output_tokens": 3},
+        ),
+        AssistantMessage(
+            [TextBlock("answer")],
+            model="claude-sonnet-4",
+            message_id="m2",
+            usage={"input_tokens": 10, "output_tokens": 3},
+        ),
+        ResultMessage(
+            result="done",
+            usage={"input_tokens": 10, "output_tokens": 1060},
+            total_cost_usd=1.23,
+            num_turns=1,
+        ),
+    ]
+    await _run(provider, messages)
+
+    llm = _llm_spans(exporter)
+    assert llm, "expected at least one anthropic.messages.create LLM span"
+    total_completion = sum((s.attributes.get(LLM_COMPLETION) or 0) for s in llm)
+    assert total_completion == 1060, f"expected 1060 (ResultMessage total), got {total_completion}"
+
+
+@pytest.mark.asyncio
+async def test_tokens_on_llm_spans_not_on_query_or_task():
+    """Token counts belong on LLM spans, never on the query/agent parent."""
+    provider, exporter = _provider()
+    messages = [
+        AssistantMessage(
+            [TextBlock("a")],
+            model="claude-sonnet-4",
+            message_id="m1",
+            usage={"input_tokens": 5, "output_tokens": 2},
+        ),
+        ResultMessage(
+            result="ok", usage={"input_tokens": 5, "output_tokens": 50}, total_cost_usd=0.1
+        ),
+    ]
+    await _run(provider, messages)
+
+    for s in exporter.get_finished_spans():
+        if s.name != "anthropic.messages.create":
+            assert s.attributes.get(LLM_COMPLETION) is None, (
+                f"{s.name} should not carry completion tokens"
+            )
+            assert s.attributes.get(LLM_PROMPT) is None, f"{s.name} should not carry prompt tokens"
+
+
+# --- Step 2: timeline / subagent spans --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_progress_only_creates_subagent_span():
+    """A subagent that streams only TaskProgress (no TaskStarted) must still get a
+    task span (named by role), parented under the Agent tool span."""
+    provider, exporter = _provider()
+    messages = [
+        AssistantMessage(
+            [ToolUseBlock(id="agent1", name="Agent", input={"subagent_type": "researcher"})],
+            model="claude-sonnet-4",
+            message_id="m1",
+            usage={"input_tokens": 5, "output_tokens": 2},
+        ),
+        TaskProgressMessage(
+            task_id="t1", description="Research OTel", tool_use_id="agent1", usage={}
+        ),
+        TaskProgressMessage(
+            task_id="t1", description="Research OTel", tool_use_id="agent1", usage={}
+        ),
+        UserMessage([ToolResultBlock(tool_use_id="agent1", content="result")]),
+        ResultMessage(
+            result="done", usage={"input_tokens": 5, "output_tokens": 50}, total_cost_usd=0.2
+        ),
+    ]
+    await _run(provider, messages)
+
+    spans = exporter.get_finished_spans()
+    names = [s.name for s in spans]
+    task_spans = [s for s in spans if s.name == "researcher"]
+    assert task_spans, f"expected a 'researcher' subagent span; got {names}"
+
+    agent_tool = [s for s in spans if s.name == "Agent"]
+    assert agent_tool, f"expected an 'Agent' tool span; got {names}"
+    assert task_spans[0].parent is not None
+    assert task_spans[0].parent.span_id == agent_tool[0].context.span_id, (
+        "subagent span must be parented under the Agent tool span, not the root query"
+    )
+
+
+@pytest.mark.asyncio
+async def test_result_usage_attaches_to_orchestrator_not_subagent():
+    """ResultMessage usage must land on the ORCHESTRATOR LLM span (parent_tool_use_id
+    is None), never a subagent turn span — even when a subagent turn is the most
+    recent LLM call."""
+    provider, exporter = _provider()
+    messages = [
+        # orchestrator turn (carries a unique marker in its output)
+        AssistantMessage(
+            "ORCHESTRATOR_MARKER",
+            model="m",
+            message_id="o1",
+            usage={"input_tokens": 5, "output_tokens": 2},
+            parent_tool_use_id=None,
+        ),
+        # a subagent turn — this is the MOST RECENT LLM span before the result
+        AssistantMessage(
+            "SUBAGENT_MARKER",
+            model="m",
+            message_id="s1",
+            usage={"input_tokens": 5, "output_tokens": 2},
+            parent_tool_use_id="sub1",
+        ),
+        ResultMessage(
+            result="done", usage={"input_tokens": 5, "output_tokens": 500}, total_cost_usd=0.1
+        ),
+    ]
+    await _run(provider, messages)
+
+    llm = [s for s in exporter.get_finished_spans() if s.name == "anthropic.messages.create"]
+    tagged = [s for s in llm if (s.attributes.get(LLM_COMPLETION) or 0) > 0]
+    assert len(tagged) == 1, f"expected exactly 1 tagged LLM span, got {len(tagged)}"
+    assert tagged[0].attributes.get(LLM_COMPLETION) == 500
+    out = tagged[0].attributes.get("output.value") or ""
+    assert "ORCHESTRATOR_MARKER" in out and "SUBAGENT_MARKER" not in out, (
+        "result usage must land on the orchestrator turn's LLM span, not the subagent turn's"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sequential_subagents_are_siblings_not_nested():
+    """Two sequential Agent subagents must be SIBLINGS under the query, not nested
+    inside each other. The orchestrator turn that spawns the 2nd subagent must parent
+    under the query, not under the still-active 1st subagent task."""
+    provider, exporter = _provider()
+    messages = [
+        AssistantMessage(
+            [ToolUseBlock(id="r1", name="Agent", input={"subagent_type": "researcher"})],
+            model="m",
+            message_id="o1",
+            parent_tool_use_id=None,
+        ),
+        TaskStartedMessage(task_id="t1", description="Research", tool_use_id="r1"),
+        AssistantMessage("researching", model="m", message_id="rt", parent_tool_use_id="r1"),
+        UserMessage([ToolResultBlock(tool_use_id="r1", content="done")]),
+        AssistantMessage(
+            [ToolUseBlock(id="a1", name="Agent", input={"subagent_type": "analyst"})],
+            model="m",
+            message_id="o2",
+            parent_tool_use_id=None,
+        ),
+        TaskStartedMessage(task_id="t2", description="Analyze", tool_use_id="a1"),
+        AssistantMessage("analyzing", model="m", message_id="at", parent_tool_use_id="a1"),
+        UserMessage([ToolResultBlock(tool_use_id="a1", content="done")]),
+        ResultMessage(
+            result="ok", usage={"input_tokens": 5, "output_tokens": 10}, total_cost_usd=0.1
+        ),
+    ]
+    await _run(provider, messages)
+
+    spans = exporter.get_finished_spans()
+    by_id = {s.context.span_id: s for s in spans}
+
+    def ancestors(span):
+        names, cur = [], span
+        while cur is not None and cur.parent is not None:
+            p = by_id.get(cur.parent.span_id)
+            if p is None:
+                break
+            names.append(p.name)
+            cur = p
+        return names
+
+    researcher = next(s for s in spans if s.name == "researcher")
+    analyst = next(s for s in spans if s.name == "analyst")
+    assert "researcher" not in ancestors(analyst), (
+        f"analyst nested under researcher; ancestors={ancestors(analyst)}"
+    )
+    assert "analyst" not in ancestors(researcher)
+
+
+@pytest.mark.asyncio
+async def test_subagent_span_named_by_role_not_description():
+    """Subagent task spans use the low-cardinality agent role (researcher/...) as the
+    span NAME, not the dynamic LLM-generated task description (which is kept as an attr)."""
+    provider, exporter = _provider()
+    messages = [
+        AssistantMessage(
+            [ToolUseBlock(id="r1", name="Agent", input={"subagent_type": "researcher"})],
+            model="m",
+            message_id="o1",
+            parent_tool_use_id=None,
+        ),
+        TaskStartedMessage(
+            task_id="t1", description="Get key OpenTelemetry AI facts", tool_use_id="r1"
+        ),
+        AssistantMessage("work", model="m", message_id="rt", parent_tool_use_id="r1"),
+        ResultMessage(
+            result="ok", usage={"input_tokens": 5, "output_tokens": 10}, total_cost_usd=0.1
+        ),
+    ]
+    await _run(provider, messages)
+
+    spans = exporter.get_finished_spans()
+    sub = next(s for s in spans if s.attributes.get("claude_agent_sdk.tool_use_id") == "r1")
+    assert sub.name == "researcher", f"expected role name, got {sub.name!r}"
+    # description preserved as an attribute, not lost
+    assert "Get key OpenTelemetry AI facts" in (sub.attributes.get("input.value") or "")
+
+
+@pytest.mark.asyncio
+async def test_all_spans_share_single_root():
+    """No orphans: every span chains back to exactly one root (the query span)."""
+    provider, exporter = _provider()
+    messages = [
+        AssistantMessage(
+            [ToolUseBlock(id="agent1", name="Agent")],
+            model="claude-sonnet-4",
+            message_id="m1",
+            usage={"input_tokens": 5, "output_tokens": 2},
+        ),
+        TaskProgressMessage(task_id="t1", description="Analyze", tool_use_id="agent1", usage={}),
+        UserMessage([ToolResultBlock(tool_use_id="agent1", content="r")]),
+        ResultMessage(
+            result="ok", usage={"input_tokens": 5, "output_tokens": 40}, total_cost_usd=0.1
+        ),
+    ]
+    await _run(provider, messages)
+
+    spans = exporter.get_finished_spans()
+    ids = {s.context.span_id for s in spans}
+    roots = [s for s in spans if s.parent is None or s.parent.span_id not in ids]
+    assert len(roots) == 1, f"expected exactly 1 root, got {len(roots)}: {[s.name for s in roots]}"
+    assert roots[0].name == "ClaudeAgent.query"

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -525,6 +525,7 @@ def wrap_query(original: Any, tracer_provider: Any = None) -> Any:
         else:
             modified_options = _Opts(hooks=merged_hooks)
 
+        error: Exception | None = None
         try:
             token = otel_context.attach(query_ctx)
             try:
@@ -533,15 +534,17 @@ def wrap_query(original: Any, tracer_provider: Any = None) -> Any:
                     yield message
             finally:
                 otel_context.detach(token)
-
-            state.end_all(StatusCode.OK)
-            query_span.set_status(StatusCode.OK)
         except Exception as exc:
-            state.end_all(StatusCode.ERROR, str(exc))
-            query_span.set_status(StatusCode.ERROR, str(exc))
-            query_span.record_exception(exc)
+            error = exc
             raise
         finally:
+            if error is not None:
+                state.end_all(StatusCode.ERROR, str(error))
+                query_span.set_status(StatusCode.ERROR, str(error))
+                query_span.record_exception(error)
+            else:
+                state.end_all(StatusCode.OK)
+                query_span.set_status(StatusCode.OK)
             query_span.end()
 
     return wrapped_query

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -245,7 +245,7 @@ class _QueryState:
             if val:
                 span.set_attribute(OI_OUTPUT_VALUE, val)
 
-        # Start tool spans from tool_use blocks in assistant messages
+        # Create tool spans from tool_use blocks
         llm_ctx = trace.set_span_in_context(span, parent_ctx)
         for msg in self.pending_messages:
             self._start_tool_spans_from_message(msg, llm_ctx)
@@ -414,7 +414,7 @@ class _QueryState:
 
 
 # ---------------------------------------------------------------------------
-# Main wrapper — no hooks, pure message-driven
+# Main wrapper — pure message-driven, no hooks
 # ---------------------------------------------------------------------------
 
 

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -384,7 +384,9 @@ class _QueryState:
             self.pending_messages.append(message)
             # Create tool spans immediately (not waiting for flush) so that
             # TaskStartedMessage can find the Agent tool span as parent.
-            self._start_tool_spans_from_message(message, self.query_ctx)
+            parent_tool_use_id = getattr(message, "parent_tool_use_id", None)
+            tool_parent_ctx = self._get_task_parent_ctx(parent_tool_use_id)
+            self._start_tool_spans_from_message(message, tool_parent_ctx)
 
         elif msg_type == "user":
             self.flush_pending_llm()

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -484,9 +484,12 @@ def _merge_hooks(
 # Main wrapper
 # ---------------------------------------------------------------------------
 
-def wrap_query(original: Any) -> Any:
+def wrap_query(original: Any, tracer_provider: Any = None) -> Any:
     """Wrap claude_agent_sdk.query() with OTel tracing."""
-    tracer = trace.get_tracer(TRACER_NAME)
+    if tracer_provider is not None:
+        tracer = tracer_provider.get_tracer(TRACER_NAME)
+    else:
+        tracer = trace.get_tracer(TRACER_NAME)
 
     async def wrapped_query(
         *,
@@ -551,12 +554,12 @@ def wrap_query(original: Any) -> Any:
 _WRAPPED = False
 
 
-def instrument_claude_agent_sdk() -> None:
+def instrument_claude_agent_sdk(tracer_provider: Any = None) -> None:
     """Monkey-patch claude_agent_sdk.query with tracing wrapper."""
     global _WRAPPED
     if _WRAPPED:
         return
     import claude_agent_sdk
 
-    claude_agent_sdk.query = wrap_query(claude_agent_sdk.query)
+    claude_agent_sdk.query = wrap_query(claude_agent_sdk.query, tracer_provider)
     _WRAPPED = True

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -3,7 +3,7 @@
 Wraps claude_agent_sdk.query() to create OTel spans for LLM calls, tools,
 and task/subagent spans with accurate token/cost tracking.
 
-Uses a message-driven approach (like Braintrust) rather than hooks:
+Uses a message-driven approach rather than hooks:
 - AssistantMessage → LLM spans (anthropic.messages.create)
 - AssistantMessage tool_use blocks → tool span start
 - UserMessage tool_result blocks → tool span end
@@ -468,7 +468,15 @@ def wrap_query(original: Any, tracer_provider: Any = None) -> Any:
             token = otel_context.attach(query_ctx)
             try:
                 async for message in original(prompt=prompt, options=options, transport=transport):
-                    state.process_message(message)
+                    # Never let instrumentation break the user's query: a bad
+                    # message shape must not propagate out of their async-for.
+                    try:
+                        state.process_message(message)
+                    except Exception:
+                        logger.warning(
+                            "traceroot: failed to process claude_agent_sdk message",
+                            exc_info=True,
+                        )
                     yield message
             finally:
                 otel_context.detach(token)

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -430,7 +430,7 @@ def _create_hooks(state: _QueryState) -> dict[str, list[Any]]:
             tool.has_subagent = True
 
         span = state.tracer.start_span(
-            agent_type or "Subagent",
+            "Subagent",
             attributes={
                 OI_SPAN_KIND: "AGENT",
                 CLAUDE_AGENT_TOOL_USE_ID: tuid,

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -1,17 +1,21 @@
 """In-house Claude Agent SDK instrumentation for TraceRoot.
 
 Wraps claude_agent_sdk.query() to create OTel spans for LLM calls, tools,
-and subagents with accurate token/cost tracking. Replaces the OpenInference
-ClaudeAgentSDKInstrumentor which produces inaccurate token counts and
-missing LLM-level spans.
+and task/subagent spans with accurate token/cost tracking.
 
-Architecture mirrors traceroot-ts/packages/traceroot/src/claude-agent-sdk.ts
+Uses a message-driven approach (like Braintrust) rather than hooks:
+- AssistantMessage → LLM spans (anthropic.messages.create)
+- AssistantMessage tool_use blocks → tool span start
+- UserMessage tool_result blocks → tool span end
+- SystemMessage TaskStarted/TaskNotification → task spans
+- ResultMessage → cost/turns metadata
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import time
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -45,8 +49,6 @@ GEN_AI_TOOL_NAME = "gen_ai.tool.name"
 CLAUDE_AGENT_MODEL = "claude_agent_sdk.model"
 CLAUDE_AGENT_NUM_TURNS = "claude_agent_sdk.num_turns"
 CLAUDE_AGENT_TOTAL_COST = "claude_agent_sdk.total_cost_usd"
-CLAUDE_AGENT_AGENT_ID = "claude_agent_sdk.agent_id"
-CLAUDE_AGENT_AGENT_TYPE = "claude_agent_sdk.agent_type"
 CLAUDE_AGENT_TOOL_USE_ID = "claude_agent_sdk.tool_use_id"
 
 
@@ -111,8 +113,7 @@ def _try_json(value: Any) -> str | None:
 
 
 def _msg_type(message: Any) -> str:
-    """Get message type from class name. Python Claude Agent SDK uses dataclasses
-    without a 'type' field, unlike the TS SDK."""
+    """Get message type from class name."""
     name = type(message).__name__
     if "Assistant" in name:
         return "assistant"
@@ -120,40 +121,44 @@ def _msg_type(message: Any) -> str:
         return "result"
     if "User" in name:
         return "user"
-    if "System" in name or "Task" in name:
+    if "Task" in name:
+        return "system"
+    if "System" in name:
         return "system"
     return name.lower()
 
 
+def _msg_subtype(message: Any) -> str | None:
+    return getattr(message, "subtype", None)
+
+
 # ---------------------------------------------------------------------------
-# Tool & subagent state
+# Active span tracking
 # ---------------------------------------------------------------------------
 
 
-class _ToolState:
-    __slots__ = ("ctx", "has_subagent", "name", "span", "tool_use_id")
+class _ToolSpan:
+    __slots__ = ("ctx", "name", "span", "tool_use_id")
 
     def __init__(self, span: trace.Span, ctx: otel_context.Context, name: str, tool_use_id: str):
         self.span = span
         self.ctx = ctx
         self.name = name
         self.tool_use_id = tool_use_id
-        self.has_subagent = False
 
 
-class _SubagentState:
-    __slots__ = ("agent_id", "ctx", "ended", "span", "tool_use_id")
+class _TaskSpan:
+    __slots__ = ("ctx", "ended", "span", "tool_use_id")
 
-    def __init__(self, span: trace.Span, ctx: otel_context.Context, tool_use_id: str):
+    def __init__(self, span: trace.Span, ctx: otel_context.Context, tool_use_id: str | None):
         self.span = span
         self.ctx = ctx
         self.tool_use_id = tool_use_id
-        self.agent_id: str | None = None
         self.ended = False
 
 
 # ---------------------------------------------------------------------------
-# Query state — tracks everything for a single query() call
+# Query state — message-driven span tracking
 # ---------------------------------------------------------------------------
 
 
@@ -170,67 +175,33 @@ class _QueryState:
         self.query_ctx = query_ctx
         self.prompt = prompt
 
+        # LLM span state
         self.current_message_id: str | None = None
         self.pending_messages: list[Any] = []
         self.pending_start_time: float | None = None
         self.accumulated_output_tokens = 0
 
-        self.tools: dict[str, _ToolState] = {}
-        self.subagents: dict[str, _SubagentState] = {}
-        self.agent_id_to_tool_use_id: dict[str, str] = {}
-        self.tool_use_to_parent: dict[str, str | None] = {}
-        # Maps Agent tool_use_id → subagent tool_use_id (they differ)
-        self.agent_tool_to_subagent: dict[str, str] = {}
-        # Dedup: maps raw SubagentStart tool_use_id → canonical tool_use_id
-        self.raw_subagent_to_canonical: dict[str, str] = {}
+        # Tool spans: tool_use_id → _ToolSpan
+        self.active_tools: dict[str, _ToolSpan] = {}
 
-    def _canonical_subagent_id(self, raw_id: str, agent_id: str | None = None) -> str:
-        """Map a SubagentStart tool_use_id to a canonical ID, deduplicating
-        multiple sub-sub-agents onto the same parent Agent tool span.
-        Mirrors TS SDK's canonicalSubagentToolUseId()."""
-        existing = self.raw_subagent_to_canonical.get(raw_id)
-        if existing:
-            return existing
+        # Task spans: tool_use_id → _TaskSpan (from SystemMessage TaskStarted)
+        self.tasks: dict[str | None, _TaskSpan] = {}
+        self.task_order: list[str | None] = []
 
-        # Direct match in tools
-        if raw_id in self.tools:
-            self.raw_subagent_to_canonical[raw_id] = raw_id
-            return raw_id
+    # -- LLM parent resolution --
 
-        # Map via agent_id → existing tool_use_id
-        if agent_id:
-            mapped = self.agent_id_to_tool_use_id.get(agent_id)
-            if mapped:
-                self.raw_subagent_to_canonical[raw_id] = mapped
-                return mapped
-
-        # Find the most recent unlinked Agent tool
-        for t in reversed(list(self.tools.values())):
-            if t.name == "Agent" and not t.has_subagent:
-                self.raw_subagent_to_canonical[raw_id] = t.tool_use_id
-                return t.tool_use_id
-
-        self.raw_subagent_to_canonical[raw_id] = raw_id
-        return raw_id
+    def _get_task_parent_ctx(self, parent_tool_use_id: str | None) -> otel_context.Context:
+        """Find the task span context for a given parent_tool_use_id."""
+        if parent_tool_use_id is not None and parent_tool_use_id in self.tasks:
+            return self.tasks[parent_tool_use_id].ctx
+        # Walk task_order in reverse to find the most recent active task
+        for key in reversed(self.task_order):
+            task = self.tasks.get(key)
+            if task and not task.ended:
+                return task.ctx
+        return self.query_ctx
 
     # -- LLM span management --
-
-    def _resolve_subagent_ctx(self, parent_tool_use_id: str | None) -> otel_context.Context | None:
-        """Find the subagent context for a given parent_tool_use_id."""
-        if not parent_tool_use_id:
-            return None
-        # Direct match
-        if parent_tool_use_id in self.subagents:
-            return self.subagents[parent_tool_use_id].ctx
-        # Agent tool_use_id → subagent mapping
-        sa_key = self.agent_tool_to_subagent.get(parent_tool_use_id)
-        if sa_key and sa_key in self.subagents:
-            return self.subagents[sa_key].ctx
-        return None
-
-    def _get_llm_parent_ctx(self, parent_tool_use_id: str | None) -> otel_context.Context:
-        ctx = self._resolve_subagent_ctx(parent_tool_use_id)
-        return ctx or self.query_ctx
 
     def flush_pending_llm(self) -> None:
         if not self.pending_messages:
@@ -240,11 +211,9 @@ class _QueryState:
         last = self.pending_messages[-1]
 
         parent_tool_use_id = getattr(first, "parent_tool_use_id", None)
-        parent_ctx = self._get_llm_parent_ctx(parent_tool_use_id)
+        parent_ctx = self._get_task_parent_ctx(parent_tool_use_id)
 
-        import time as _time
-
-        start = self.pending_start_time or _time.time()
+        start = self.pending_start_time or time.time()
         span = self.tracer.start_span(
             LLM_SPAN_NAME,
             attributes={OI_SPAN_KIND: "LLM"},
@@ -276,6 +245,11 @@ class _QueryState:
             if val:
                 span.set_attribute(OI_OUTPUT_VALUE, val)
 
+        # Start tool spans from tool_use blocks in assistant messages
+        llm_ctx = trace.set_span_in_context(span, parent_ctx)
+        for msg in self.pending_messages:
+            self._start_tool_spans_from_message(msg, llm_ctx)
+
         span.set_status(StatusCode.OK)
         span.end()
 
@@ -284,37 +258,124 @@ class _QueryState:
         self.pending_messages = []
         self.pending_start_time = None
 
-    # -- Tool use tracking from assistant messages --
-
-    def _track_tool_use_context(self, message: Any) -> None:
-        if _msg_type(message) != "assistant":
-            return
+    def _start_tool_spans_from_message(self, message: Any, llm_ctx: otel_context.Context) -> None:
+        """Create tool spans from tool_use blocks in an AssistantMessage."""
         content = getattr(message, "content", None)
         if not isinstance(content, list):
             return
-        parent_tool_use_id = getattr(message, "parent_tool_use_id", None)
         for block in content:
-            block_type = getattr(block, "type", None)
-            block_id = getattr(block, "id", None)
-            if block_type == "tool_use" and isinstance(block_id, str):
-                self.tool_use_to_parent[block_id] = parent_tool_use_id
+            if type(block).__name__ != "ToolUseBlock":
+                continue
+            tool_use_id = getattr(block, "id", None)
+            if not tool_use_id:
+                continue
+            tool_use_id = str(tool_use_id)
+            tool_name = str(getattr(block, "name", "tool"))
+            tool_input = getattr(block, "input", None)
+
+            tool_span = self.tracer.start_span(
+                tool_name,
+                attributes={
+                    OI_SPAN_KIND: "TOOL",
+                    TOOL_NAME_ATTR: tool_name,
+                    GEN_AI_TOOL_NAME: tool_name,
+                    GEN_AI_TOOL_CALL_ID: tool_use_id,
+                },
+                context=llm_ctx,
+            )
+            if tool_input:
+                val = _try_json(tool_input)
+                if val:
+                    tool_span.set_attribute(OI_INPUT_VALUE, val)
+
+            tool_ctx = trace.set_span_in_context(tool_span, llm_ctx)
+            self.active_tools[tool_use_id] = _ToolSpan(tool_span, tool_ctx, tool_name, tool_use_id)
+
+    def _finish_tool_spans_from_message(self, message: Any) -> None:
+        """End tool spans from tool_result blocks in a UserMessage."""
+        content = getattr(message, "content", None)
+        if not isinstance(content, list):
+            return
+        for block in content:
+            if type(block).__name__ != "ToolResultBlock":
+                continue
+            tool_use_id = getattr(block, "tool_use_id", None)
+            if not tool_use_id:
+                continue
+            tool_use_id = str(tool_use_id)
+            tool = self.active_tools.pop(tool_use_id, None)
+            if not tool:
+                continue
+
+            tool_content = getattr(block, "content", None)
+            if tool_content:
+                val = _try_json(tool_content)
+                if val:
+                    tool.span.set_attribute(OI_OUTPUT_VALUE, val)
+
+            is_error = getattr(block, "is_error", False)
+            if is_error:
+                tool.span.set_status(StatusCode.ERROR, "tool error")
+            else:
+                tool.span.set_status(StatusCode.OK)
+            tool.span.end()
+
+    # -- Task span management (from SystemMessage) --
+
+    def _handle_task_event(self, message: Any) -> None:
+        """Create/update/end task spans from TaskStarted/TaskNotification."""
+        msg_cls = type(message).__name__
+        tool_use_id = getattr(message, "tool_use_id", None)
+        tool_use_id_str = str(tool_use_id) if tool_use_id is not None else None
+
+        if msg_cls == "TaskStartedMessage":
+            if tool_use_id_str in self.tasks:
+                return
+            # Find parent: the Agent tool span if it exists
+            parent_ctx = self.query_ctx
+            if tool_use_id_str and tool_use_id_str in self.active_tools:
+                parent_ctx = self.active_tools[tool_use_id_str].ctx
+
+            description = getattr(message, "description", None)
+            task_type = getattr(message, "task_type", None)
+            span_name = (
+                str(description) if description else (str(task_type) if task_type else "Task")
+            )
+
+            task_span = self.tracer.start_span(
+                span_name,
+                attributes={OI_SPAN_KIND: "AGENT", CLAUDE_AGENT_TOOL_USE_ID: tool_use_id_str or ""},
+                context=parent_ctx,
+            )
+            task_ctx = trace.set_span_in_context(task_span, parent_ctx)
+            self.tasks[tool_use_id_str] = _TaskSpan(task_span, task_ctx, tool_use_id_str)
+            self.task_order.append(tool_use_id_str)
+
+        elif msg_cls == "TaskNotificationMessage":
+            task = self.tasks.get(tool_use_id_str)
+            if task and not task.ended:
+                task.span.set_status(StatusCode.OK)
+                task.span.end()
+                task.ended = True
+                self.task_order = [k for k in self.task_order if k != tool_use_id_str]
 
     # -- Message processing --
 
     def process_message(self, message: Any) -> None:
-        self._track_tool_use_context(message)
         msg_type = _msg_type(message)
 
         if msg_type == "assistant":
-            import time as _time
-
             message_id = getattr(message, "message_id", None)
             if message_id and message_id != self.current_message_id:
                 self.flush_pending_llm()
                 self.current_message_id = message_id
             if not self.pending_messages:
-                self.pending_start_time = _time.time()
+                self.pending_start_time = time.time()
             self.pending_messages.append(message)
+
+        elif msg_type == "user":
+            self.flush_pending_llm()
+            self._finish_tool_spans_from_message(message)
 
         elif msg_type == "result":
             self.flush_pending_llm()
@@ -331,212 +392,28 @@ class _QueryState:
             if isinstance(session_id, str):
                 self.query_span.set_attribute(OI_TRACE_SESSION_ID, session_id)
 
+        elif msg_type == "system":
+            self._handle_task_event(message)
+
     # -- Cleanup --
 
     def end_all(self, status: StatusCode = StatusCode.OK, error: str | None = None) -> None:
         self.flush_pending_llm()
-        for tool in self.tools.values():
+        for tool in self.active_tools.values():
             tool.span.set_status(status, error)
             tool.span.end()
-        self.tools.clear()
-        for sub in self.subagents.values():
-            if not sub.ended:
-                sub.span.set_status(status, error)
-                sub.span.end()
-                sub.ended = True
-        self.subagents.clear()
+        self.active_tools.clear()
+        for task in self.tasks.values():
+            if not task.ended:
+                task.span.set_status(status, error)
+                task.span.end()
+                task.ended = True
+        self.tasks.clear()
+        self.task_order.clear()
 
 
 # ---------------------------------------------------------------------------
-# Hook creation — injected into query options
-# ---------------------------------------------------------------------------
-
-
-def _create_hooks(state: _QueryState) -> dict[str, list[Any]]:
-    from claude_agent_sdk.types import HookMatcher
-
-    async def pre_tool_use(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
-        name = input_data.get("tool_name", "tool")
-        tuid = tool_use_id or input_data.get("tool_use_id", "")
-        if not tuid:
-            return {}
-
-        parent_tool_use_id = state.tool_use_to_parent.get(tuid)
-        parent_ctx = state._get_llm_parent_ctx(parent_tool_use_id)
-
-        # If this tool runs inside a subagent, parent under the subagent span
-        agent_id = input_data.get("agent_id")
-        if agent_id:
-            sa_tuid = state.agent_id_to_tool_use_id.get(agent_id)
-            if sa_tuid and sa_tuid in state.subagents:
-                parent_ctx = state.subagents[sa_tuid].ctx
-
-        span = state.tracer.start_span(
-            name,
-            attributes={
-                OI_SPAN_KIND: "TOOL",
-                TOOL_NAME_ATTR: name,
-                GEN_AI_TOOL_NAME: name,
-                GEN_AI_TOOL_CALL_ID: tuid,
-            },
-            context=parent_ctx,
-        )
-        tool_input = input_data.get("tool_input")
-        if tool_input:
-            val = _try_json(tool_input)
-            if val:
-                span.set_attribute(OI_INPUT_VALUE, val)
-
-        tool_ctx = trace.set_span_in_context(span, parent_ctx)
-        state.tools[tuid] = _ToolState(span, tool_ctx, name, tuid)
-        return {}
-
-    async def post_tool_use(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
-        tuid = tool_use_id or input_data.get("tool_use_id", "")
-        tool = state.tools.pop(tuid, None)
-        if tool:
-            response = input_data.get("tool_response")
-            if response:
-                val = _try_json(response)
-                if val:
-                    tool.span.set_attribute(OI_OUTPUT_VALUE, val)
-            tool.span.set_status(StatusCode.OK)
-            tool.span.end()
-
-        # End subagent if this was an Agent tool
-        sub = state.subagents.get(tuid)
-        if sub and not sub.ended:
-            response = input_data.get("tool_response")
-            if response and isinstance(response, dict):
-                agent_type = response.get("agentType")
-                if agent_type:
-                    sub.span.set_attribute(CLAUDE_AGENT_AGENT_TYPE, str(agent_type))
-                content = response.get("content")
-                if content:
-                    val = _try_json(content)
-                    if val:
-                        sub.span.set_attribute(OI_OUTPUT_VALUE, val)
-            sub.span.set_status(StatusCode.OK)
-            sub.span.end()
-            sub.ended = True
-        return {}
-
-    async def post_tool_use_failure(
-        input_data: dict[str, Any], tool_use_id: str | None, ctx: Any
-    ) -> dict:
-        tuid = tool_use_id or input_data.get("tool_use_id", "")
-        error_msg = input_data.get("error", "Tool failed")
-        tool = state.tools.pop(tuid, None)
-        if tool:
-            tool.span.set_status(StatusCode.ERROR, str(error_msg))
-            tool.span.record_exception(Exception(str(error_msg)))
-            tool.span.end()
-
-        sub = state.subagents.get(tuid)
-        if sub and not sub.ended:
-            sub.span.set_status(StatusCode.ERROR, str(error_msg))
-            sub.span.end()
-            sub.ended = True
-        return {}
-
-    async def subagent_start(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
-        agent_id = input_data.get("agent_id", "")
-        agent_type = input_data.get("agent_type", "")
-        raw_tuid = tool_use_id or ""
-        if not raw_tuid:
-            return {}
-
-        # Deduplicate: map raw tool_use_id to canonical ID so multiple
-        # sub-sub-agents reuse the same Subagent span (matches TS SDK).
-        tuid = state._canonical_subagent_id(raw_tuid, agent_id)
-
-        # If subagent already exists for this canonical ID, just update mapping
-        existing = state.subagents.get(tuid)
-        if existing:
-            if agent_id:
-                existing.agent_id = agent_id
-                state.agent_id_to_tool_use_id[agent_id] = tuid
-                existing.span.set_attribute(CLAUDE_AGENT_AGENT_ID, agent_id)
-            if agent_type:
-                existing.span.set_attribute(CLAUDE_AGENT_AGENT_TYPE, agent_type)
-            return {}
-
-        # Find the Agent tool span to parent under
-        tool = state.tools.get(tuid)
-        if not tool:
-            for t in reversed(list(state.tools.values())):
-                if t.name == "Agent" and not t.has_subagent:
-                    tool = t
-                    state.agent_tool_to_subagent[t.tool_use_id] = tuid
-                    break
-        parent_ctx = tool.ctx if tool else state.query_ctx
-        if tool:
-            tool.has_subagent = True
-
-        span = state.tracer.start_span(
-            agent_type or "Subagent",
-            attributes={
-                OI_SPAN_KIND: "AGENT",
-                CLAUDE_AGENT_TOOL_USE_ID: tuid,
-            },
-            context=parent_ctx,
-        )
-        if agent_id:
-            span.set_attribute(CLAUDE_AGENT_AGENT_ID, agent_id)
-        if agent_type:
-            span.set_attribute(CLAUDE_AGENT_AGENT_TYPE, agent_type)
-
-        sub_ctx = trace.set_span_in_context(span, parent_ctx)
-        sub = _SubagentState(span, sub_ctx, tuid)
-        sub.agent_id = agent_id
-        state.subagents[tuid] = sub
-        if agent_id:
-            state.agent_id_to_tool_use_id[agent_id] = tuid
-        return {}
-
-    async def subagent_stop(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
-        raw_tuid = tool_use_id or ""
-        tuid = state._canonical_subagent_id(raw_tuid, input_data.get("agent_id"))
-        sub = state.subagents.get(tuid)
-        if not sub or sub.ended:
-            return {}
-        last_msg = input_data.get("last_assistant_message")
-        if last_msg:
-            val = _try_json(last_msg)
-            if val:
-                sub.span.set_attribute(OI_OUTPUT_VALUE, val)
-        sub.span.set_status(StatusCode.OK)
-        sub.span.end()
-        sub.ended = True
-        return {}
-
-    return {
-        "PreToolUse": [HookMatcher(hooks=[pre_tool_use])],
-        "PostToolUse": [HookMatcher(hooks=[post_tool_use])],
-        "PostToolUseFailure": [HookMatcher(hooks=[post_tool_use_failure])],
-        "SubagentStart": [HookMatcher(hooks=[subagent_start])],
-        "SubagentStop": [HookMatcher(hooks=[subagent_stop])],
-    }
-
-
-# ---------------------------------------------------------------------------
-# Hook merging
-# ---------------------------------------------------------------------------
-
-
-def _merge_hooks(
-    options: Any | None,
-    tracing_hooks: dict[str, list[dict[str, Any]]],
-) -> dict[str, list[Any]]:
-    existing = getattr(options, "hooks", None) or {}
-    merged = dict(existing)
-    for event, matchers in tracing_hooks.items():
-        merged[event] = list(merged.get(event, [])) + matchers
-    return merged
-
-
-# ---------------------------------------------------------------------------
-# Main wrapper
+# Main wrapper — no hooks, pure message-driven
 # ---------------------------------------------------------------------------
 
 
@@ -571,26 +448,11 @@ def wrap_query(original: Any, tracer_provider: Any = None) -> Any:
             tracer, query_span, query_ctx, prompt if isinstance(prompt, str) else None
         )
 
-        # Inject tracing hooks into options
-        hooks = _create_hooks(state)
-        merged_hooks = _merge_hooks(options, hooks)
-
-        import dataclasses
-
-        from claude_agent_sdk.types import ClaudeAgentOptions as _Opts
-
-        if options is not None and dataclasses.is_dataclass(options):
-            modified_options = dataclasses.replace(options, hooks=merged_hooks)
-        else:
-            modified_options = _Opts(hooks=merged_hooks)
-
         error: Exception | None = None
         try:
             token = otel_context.attach(query_ctx)
             try:
-                async for message in original(
-                    prompt=prompt, options=modified_options, transport=transport
-                ):
+                async for message in original(prompt=prompt, options=options, transport=transport):
                     state.process_message(message)
                     yield message
             finally:

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -301,10 +301,12 @@ class _QueryState:
     def end_all(self, status: StatusCode = StatusCode.OK, error: str | None = None) -> None:
         self.flush_pending_llm()
         for tool in self.tools.values():
+            tool.span.set_status(status, error)
             tool.span.end()
         self.tools.clear()
         for sub in self.subagents.values():
             if not sub.ended:
+                sub.span.set_status(status, error)
                 sub.span.end()
                 sub.ended = True
         self.subagents.clear()

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -1,0 +1,560 @@
+"""In-house Claude Agent SDK instrumentation for TraceRoot.
+
+Wraps claude_agent_sdk.query() to create OTel spans for LLM calls, tools,
+and subagents with accurate token/cost tracking. Replaces the OpenInference
+ClaudeAgentSDKInstrumentor which produces inaccurate token counts and
+missing LLM-level spans.
+
+Architecture mirrors traceroot-ts/packages/traceroot/src/claude-agent-sdk.ts
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+from opentelemetry import context as otel_context, trace
+from opentelemetry.trace import StatusCode
+
+logger = logging.getLogger(__name__)
+
+TRACER_NAME = "traceroot.claude-agent-sdk"
+QUERY_SPAN_NAME = "ClaudeAgent.query"
+LLM_SPAN_NAME = "anthropic.messages.create"
+
+# OpenInference attribute keys
+OI_SPAN_KIND = "openinference.span.kind"
+OI_INPUT_VALUE = "input.value"
+OI_OUTPUT_VALUE = "output.value"
+OI_LLM_MODEL_NAME = "llm.model_name"
+OI_LLM_TOKEN_COUNT_PROMPT = "llm.token_count.prompt"
+OI_LLM_TOKEN_COUNT_COMPLETION = "llm.token_count.completion"
+OI_TRACE_SESSION_ID = "session.id"
+TOOL_NAME_ATTR = "tool.name"
+
+LLM_TOKEN_TOTAL = "llm.token_count.total"
+LLM_TOKEN_CACHE_READ = "llm.token_count.prompt_details.cache_read"
+LLM_TOKEN_CACHE_CREATION = "llm.token_count.prompt_details.cache_creation"
+GEN_AI_RESPONSE_MODEL = "gen_ai.response.model"
+GEN_AI_TOOL_CALL_ID = "gen_ai.tool.call.id"
+GEN_AI_TOOL_NAME = "gen_ai.tool.name"
+
+CLAUDE_AGENT_MODEL = "claude_agent_sdk.model"
+CLAUDE_AGENT_NUM_TURNS = "claude_agent_sdk.num_turns"
+CLAUDE_AGENT_TOTAL_COST = "claude_agent_sdk.total_cost_usd"
+CLAUDE_AGENT_AGENT_ID = "claude_agent_sdk.agent_id"
+CLAUDE_AGENT_AGENT_TYPE = "claude_agent_sdk.agent_type"
+CLAUDE_AGENT_TOOL_USE_ID = "claude_agent_sdk.tool_use_id"
+
+
+def extract_usage(usage: dict[str, Any] | None) -> dict[str, int]:
+    """Extract normalized token metrics from Anthropic usage dict."""
+    if not usage:
+        return {}
+
+    input_tokens = usage.get("input_tokens", 0) or 0
+    output_tokens = usage.get("output_tokens", 0) or 0
+    cache_read = usage.get("cache_read_input_tokens", 0) or 0
+    cache_creation = usage.get("cache_creation_input_tokens", 0) or 0
+
+    prompt_tokens = input_tokens + cache_read + cache_creation
+
+    result: dict[str, int] = {}
+    if prompt_tokens > 0:
+        result["prompt_tokens"] = prompt_tokens
+    if output_tokens > 0:
+        result["completion_tokens"] = output_tokens
+    if prompt_tokens + output_tokens > 0:
+        result["total_tokens"] = prompt_tokens + output_tokens
+    if cache_read > 0:
+        result["prompt_cached_tokens"] = cache_read
+    if cache_creation > 0:
+        result["prompt_cache_creation_tokens"] = cache_creation
+    return result
+
+
+def _set_usage_attrs(span: trace.Span, usage: dict[str, Any] | None) -> None:
+    metrics = extract_usage(usage)
+    if not metrics:
+        return
+    if "prompt_tokens" in metrics:
+        span.set_attribute(OI_LLM_TOKEN_COUNT_PROMPT, metrics["prompt_tokens"])
+    if "completion_tokens" in metrics:
+        span.set_attribute(OI_LLM_TOKEN_COUNT_COMPLETION, metrics["completion_tokens"])
+    if "total_tokens" in metrics:
+        span.set_attribute(LLM_TOKEN_TOTAL, metrics["total_tokens"])
+    if "prompt_cached_tokens" in metrics:
+        span.set_attribute(LLM_TOKEN_CACHE_READ, metrics["prompt_cached_tokens"])
+    if "prompt_cache_creation_tokens" in metrics:
+        span.set_attribute(LLM_TOKEN_CACHE_CREATION, metrics["prompt_cache_creation_tokens"])
+
+
+def _set_model(span: trace.Span, model: str | None) -> None:
+    if not model:
+        return
+    span.set_attribute(OI_LLM_MODEL_NAME, model)
+    span.set_attribute(GEN_AI_RESPONSE_MODEL, model)
+
+
+def _try_json(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return str(value)
+
+
+def _msg_type(message: Any) -> str:
+    """Get message type from class name. Python Claude Agent SDK uses dataclasses
+    without a 'type' field, unlike the TS SDK."""
+    name = type(message).__name__
+    if "Assistant" in name:
+        return "assistant"
+    if "Result" in name:
+        return "result"
+    if "User" in name:
+        return "user"
+    if "System" in name or "Task" in name:
+        return "system"
+    return name.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tool & subagent state
+# ---------------------------------------------------------------------------
+
+class _ToolState:
+    __slots__ = ("span", "ctx", "name", "tool_use_id", "has_subagent")
+
+    def __init__(self, span: trace.Span, ctx: otel_context.Context, name: str, tool_use_id: str):
+        self.span = span
+        self.ctx = ctx
+        self.name = name
+        self.tool_use_id = tool_use_id
+        self.has_subagent = False
+
+
+class _SubagentState:
+    __slots__ = ("span", "ctx", "tool_use_id", "agent_id", "ended")
+
+    def __init__(self, span: trace.Span, ctx: otel_context.Context, tool_use_id: str):
+        self.span = span
+        self.ctx = ctx
+        self.tool_use_id = tool_use_id
+        self.agent_id: str | None = None
+        self.ended = False
+
+
+# ---------------------------------------------------------------------------
+# Query state — tracks everything for a single query() call
+# ---------------------------------------------------------------------------
+
+class _QueryState:
+    def __init__(
+        self,
+        tracer: trace.Tracer,
+        query_span: trace.Span,
+        query_ctx: otel_context.Context,
+        prompt: str | None,
+    ):
+        self.tracer = tracer
+        self.query_span = query_span
+        self.query_ctx = query_ctx
+        self.prompt = prompt
+
+        self.current_message_id: str | None = None
+        self.pending_messages: list[Any] = []
+        self.pending_start_time: float | None = None
+        self.accumulated_output_tokens = 0
+
+        self.tools: dict[str, _ToolState] = {}
+        self.subagents: dict[str, _SubagentState] = {}
+        self.agent_id_to_tool_use_id: dict[str, str] = {}
+        self.tool_use_to_parent: dict[str, str | None] = {}
+        # Maps Agent tool_use_id → subagent tool_use_id (they differ)
+        self.agent_tool_to_subagent: dict[str, str] = {}
+
+    # -- LLM span management --
+
+    def _resolve_subagent_ctx(self, parent_tool_use_id: str | None) -> otel_context.Context | None:
+        """Find the subagent context for a given parent_tool_use_id."""
+        if not parent_tool_use_id:
+            return None
+        # Direct match
+        if parent_tool_use_id in self.subagents:
+            return self.subagents[parent_tool_use_id].ctx
+        # Agent tool_use_id → subagent mapping
+        sa_key = self.agent_tool_to_subagent.get(parent_tool_use_id)
+        if sa_key and sa_key in self.subagents:
+            return self.subagents[sa_key].ctx
+        return None
+
+    def _get_llm_parent_ctx(self, parent_tool_use_id: str | None) -> otel_context.Context:
+        ctx = self._resolve_subagent_ctx(parent_tool_use_id)
+        return ctx or self.query_ctx
+
+    def flush_pending_llm(self) -> None:
+        if not self.pending_messages:
+            return
+
+        first = self.pending_messages[0]
+        last = self.pending_messages[-1]
+
+        parent_tool_use_id = getattr(first, "parent_tool_use_id", None)
+        parent_ctx = self._get_llm_parent_ctx(parent_tool_use_id)
+
+        import time as _time
+        start = self.pending_start_time or _time.time()
+        span = self.tracer.start_span(
+            LLM_SPAN_NAME,
+            attributes={OI_SPAN_KIND: "LLM"},
+            context=parent_ctx,
+            start_time=int(start * 1e9),
+        )
+
+        model = getattr(last, "model", None)
+        if not model:
+            for msg in reversed(self.pending_messages):
+                model = getattr(msg, "model", None)
+                if model:
+                    break
+        _set_model(span, model)
+        _set_usage_attrs(span, getattr(last, "usage", None))
+
+        if not parent_tool_use_id and self.prompt:
+            val = _try_json([{"role": "user", "content": self.prompt}])
+            if val:
+                span.set_attribute(OI_INPUT_VALUE, val)
+
+        output_parts = []
+        for msg in self.pending_messages:
+            content = getattr(msg, "content", None)
+            if content is not None:
+                output_parts.append({"role": "assistant", "content": content})
+        if output_parts:
+            val = _try_json(output_parts)
+            if val:
+                span.set_attribute(OI_OUTPUT_VALUE, val)
+
+        span.set_status(StatusCode.OK)
+        span.end()
+
+        usage = getattr(last, "usage", None) or {}
+        self.accumulated_output_tokens += usage.get("output_tokens", 0)
+        self.pending_messages = []
+        self.pending_start_time = None
+
+    # -- Tool use tracking from assistant messages --
+
+    def _track_tool_use_context(self, message: Any) -> None:
+        if _msg_type(message) != "assistant":
+            return
+        content = getattr(message, "content", None)
+        if not isinstance(content, list):
+            return
+        parent_tool_use_id = getattr(message, "parent_tool_use_id", None)
+        for block in content:
+            block_type = getattr(block, "type", None)
+            block_id = getattr(block, "id", None)
+            if block_type == "tool_use" and isinstance(block_id, str):
+                self.tool_use_to_parent[block_id] = parent_tool_use_id
+
+    # -- Message processing --
+
+    def process_message(self, message: Any) -> None:
+        self._track_tool_use_context(message)
+        msg_type = _msg_type(message)
+
+        if msg_type == "assistant":
+            import time as _time
+            message_id = getattr(message, "message_id", None)
+            if message_id and message_id != self.current_message_id:
+                self.flush_pending_llm()
+                self.current_message_id = message_id
+            if not self.pending_messages:
+                self.pending_start_time = _time.time()
+            self.pending_messages.append(message)
+
+        elif msg_type == "result":
+            self.flush_pending_llm()
+            result = getattr(message, "result", None)
+            if isinstance(result, str):
+                self.query_span.set_attribute(OI_OUTPUT_VALUE, result)
+            total_cost = getattr(message, "total_cost_usd", None)
+            if total_cost is not None:
+                self.query_span.set_attribute(CLAUDE_AGENT_TOTAL_COST, total_cost)
+            num_turns = getattr(message, "num_turns", None)
+            if isinstance(num_turns, int):
+                self.query_span.set_attribute(CLAUDE_AGENT_NUM_TURNS, num_turns)
+            session_id = getattr(message, "session_id", None)
+            if isinstance(session_id, str):
+                self.query_span.set_attribute(OI_TRACE_SESSION_ID, session_id)
+
+    # -- Cleanup --
+
+    def end_all(self, status: StatusCode = StatusCode.OK, error: str | None = None) -> None:
+        self.flush_pending_llm()
+        for tool in self.tools.values():
+            tool.span.end()
+        self.tools.clear()
+        for sub in self.subagents.values():
+            if not sub.ended:
+                sub.span.end()
+                sub.ended = True
+        self.subagents.clear()
+
+
+# ---------------------------------------------------------------------------
+# Hook creation — injected into query options
+# ---------------------------------------------------------------------------
+
+def _create_hooks(state: _QueryState) -> dict[str, list[Any]]:
+    from claude_agent_sdk.types import HookMatcher
+
+    async def pre_tool_use(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
+        name = input_data.get("tool_name", "tool")
+        tuid = tool_use_id or input_data.get("tool_use_id", "")
+        if not tuid:
+            return {}
+
+        parent_tool_use_id = state.tool_use_to_parent.get(tuid)
+        parent_ctx = state._get_llm_parent_ctx(parent_tool_use_id)
+
+        # If this tool runs inside a subagent, parent under the subagent span
+        agent_id = input_data.get("agent_id")
+        if agent_id:
+            sa_tuid = state.agent_id_to_tool_use_id.get(agent_id)
+            if sa_tuid and sa_tuid in state.subagents:
+                parent_ctx = state.subagents[sa_tuid].ctx
+
+        span = state.tracer.start_span(
+            name,
+            attributes={
+                OI_SPAN_KIND: "TOOL",
+                TOOL_NAME_ATTR: name,
+                GEN_AI_TOOL_NAME: name,
+                GEN_AI_TOOL_CALL_ID: tuid,
+            },
+            context=parent_ctx,
+        )
+        tool_input = input_data.get("tool_input")
+        if tool_input:
+            val = _try_json(tool_input)
+            if val:
+                span.set_attribute(OI_INPUT_VALUE, val)
+
+        tool_ctx = trace.set_span_in_context(span, parent_ctx)
+        state.tools[tuid] = _ToolState(span, tool_ctx, name, tuid)
+        return {}
+
+    async def post_tool_use(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
+        tuid = tool_use_id or input_data.get("tool_use_id", "")
+        tool = state.tools.pop(tuid, None)
+        if tool:
+            response = input_data.get("tool_response")
+            if response:
+                val = _try_json(response)
+                if val:
+                    tool.span.set_attribute(OI_OUTPUT_VALUE, val)
+            tool.span.set_status(StatusCode.OK)
+            tool.span.end()
+
+        # End subagent if this was an Agent tool
+        sub = state.subagents.get(tuid)
+        if sub and not sub.ended:
+            response = input_data.get("tool_response")
+            if response and isinstance(response, dict):
+                agent_type = response.get("agentType")
+                if agent_type:
+                    sub.span.set_attribute(CLAUDE_AGENT_AGENT_TYPE, str(agent_type))
+                content = response.get("content")
+                if content:
+                    val = _try_json(content)
+                    if val:
+                        sub.span.set_attribute(OI_OUTPUT_VALUE, val)
+            sub.span.set_status(StatusCode.OK)
+            sub.span.end()
+            sub.ended = True
+        return {}
+
+    async def post_tool_use_failure(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
+        tuid = tool_use_id or input_data.get("tool_use_id", "")
+        error_msg = input_data.get("error", "Tool failed")
+        tool = state.tools.pop(tuid, None)
+        if tool:
+            tool.span.set_status(StatusCode.ERROR, str(error_msg))
+            tool.span.record_exception(Exception(str(error_msg)))
+            tool.span.end()
+
+        sub = state.subagents.get(tuid)
+        if sub and not sub.ended:
+            sub.span.set_status(StatusCode.ERROR, str(error_msg))
+            sub.span.end()
+            sub.ended = True
+        return {}
+
+    async def subagent_start(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
+        agent_id = input_data.get("agent_id", "")
+        agent_type = input_data.get("agent_type", "")
+        tuid = tool_use_id or ""
+        if not tuid:
+            return {}
+
+        # Find the Agent tool span to parent under.
+        # SubagentStart's tool_use_id differs from the Agent tool's tool_use_id,
+        # so find the most recent unlinked Agent tool and map them.
+        tool = state.tools.get(tuid)
+        if not tool:
+            for t in reversed(list(state.tools.values())):
+                if t.name == "Agent" and not t.has_subagent:
+                    tool = t
+                    state.agent_tool_to_subagent[t.tool_use_id] = tuid
+                    break
+        parent_ctx = tool.ctx if tool else state.query_ctx
+        if tool:
+            tool.has_subagent = True
+
+        span = state.tracer.start_span(
+            agent_type or "Subagent",
+            attributes={
+                OI_SPAN_KIND: "AGENT",
+                CLAUDE_AGENT_TOOL_USE_ID: tuid,
+            },
+            context=parent_ctx,
+        )
+        if agent_id:
+            span.set_attribute(CLAUDE_AGENT_AGENT_ID, agent_id)
+        if agent_type:
+            span.set_attribute(CLAUDE_AGENT_AGENT_TYPE, agent_type)
+
+        sub_ctx = trace.set_span_in_context(span, parent_ctx)
+        sub = _SubagentState(span, sub_ctx, tuid)
+        sub.agent_id = agent_id
+        state.subagents[tuid] = sub
+        if agent_id:
+            state.agent_id_to_tool_use_id[agent_id] = tuid
+        return {}
+
+    async def subagent_stop(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
+        tuid = tool_use_id or ""
+        sub = state.subagents.get(tuid)
+        if not sub or sub.ended:
+            return {}
+        last_msg = input_data.get("last_assistant_message")
+        if last_msg:
+            val = _try_json(last_msg)
+            if val:
+                sub.span.set_attribute(OI_OUTPUT_VALUE, val)
+        sub.span.set_status(StatusCode.OK)
+        sub.span.end()
+        sub.ended = True
+        return {}
+
+    return {
+        "PreToolUse": [HookMatcher(hooks=[pre_tool_use])],
+        "PostToolUse": [HookMatcher(hooks=[post_tool_use])],
+        "PostToolUseFailure": [HookMatcher(hooks=[post_tool_use_failure])],
+        "SubagentStart": [HookMatcher(hooks=[subagent_start])],
+        "SubagentStop": [HookMatcher(hooks=[subagent_stop])],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hook merging
+# ---------------------------------------------------------------------------
+
+def _merge_hooks(
+    options: Any | None,
+    tracing_hooks: dict[str, list[dict[str, Any]]],
+) -> dict[str, list[Any]]:
+    existing = getattr(options, "hooks", None) or {}
+    merged = dict(existing)
+    for event, matchers in tracing_hooks.items():
+        merged[event] = list(merged.get(event, [])) + matchers
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Main wrapper
+# ---------------------------------------------------------------------------
+
+def wrap_query(original: Any) -> Any:
+    """Wrap claude_agent_sdk.query() with OTel tracing."""
+    tracer = trace.get_tracer(TRACER_NAME)
+
+    async def wrapped_query(
+        *,
+        prompt: Any,
+        options: Any = None,
+        transport: Any = None,
+    ) -> AsyncIterator[Any]:
+        parent_ctx = otel_context.get_current()
+        query_span = tracer.start_span(
+            QUERY_SPAN_NAME,
+            attributes={OI_SPAN_KIND: "AGENT"},
+            context=parent_ctx,
+        )
+        if isinstance(prompt, str):
+            query_span.set_attribute(OI_INPUT_VALUE, prompt)
+
+        model = getattr(options, "model", None) if options else None
+        if model:
+            query_span.set_attribute(CLAUDE_AGENT_MODEL, model)
+
+        query_ctx = trace.set_span_in_context(query_span, parent_ctx)
+        state = _QueryState(tracer, query_span, query_ctx, prompt if isinstance(prompt, str) else None)
+
+        # Inject tracing hooks into options
+        hooks = _create_hooks(state)
+        merged_hooks = _merge_hooks(options, hooks)
+
+        import dataclasses
+        from claude_agent_sdk.types import ClaudeAgentOptions as _Opts
+        if options is not None and dataclasses.is_dataclass(options):
+            modified_options = dataclasses.replace(options, hooks=merged_hooks)
+        else:
+            modified_options = _Opts(hooks=merged_hooks)
+
+        try:
+            token = otel_context.attach(query_ctx)
+            try:
+                async for message in original(prompt=prompt, options=modified_options, transport=transport):
+                    state.process_message(message)
+                    yield message
+            finally:
+                otel_context.detach(token)
+
+            state.end_all(StatusCode.OK)
+            query_span.set_status(StatusCode.OK)
+        except Exception as exc:
+            state.end_all(StatusCode.ERROR, str(exc))
+            query_span.set_status(StatusCode.ERROR, str(exc))
+            query_span.record_exception(exc)
+            raise
+        finally:
+            query_span.end()
+
+    return wrapped_query
+
+
+# ---------------------------------------------------------------------------
+# Public entry point — called by registry
+# ---------------------------------------------------------------------------
+
+_WRAPPED = False
+
+
+def instrument_claude_agent_sdk() -> None:
+    """Monkey-patch claude_agent_sdk.query with tracing wrapper."""
+    global _WRAPPED
+    if _WRAPPED:
+        return
+    import claude_agent_sdk
+
+    claude_agent_sdk.query = wrap_query(claude_agent_sdk.query)
+    _WRAPPED = True

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -519,7 +519,7 @@ def wrap_query(original: Any, tracer_provider: Any = None) -> Any:
         hooks = _create_hooks(state)
         merged_hooks = _merge_hooks(options, hooks)
 
-        import dataclasses  # noqa: I001
+        import dataclasses
 
         from claude_agent_sdk.types import ClaudeAgentOptions as _Opts
         if options is not None and dataclasses.is_dataclass(options):

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -430,7 +430,7 @@ def _create_hooks(state: _QueryState) -> dict[str, list[Any]]:
             tool.has_subagent = True
 
         span = state.tracer.start_span(
-            "Subagent",
+            agent_type or "Subagent",
             attributes={
                 OI_SPAN_KIND: "AGENT",
                 CLAUDE_AGENT_TOOL_USE_ID: tuid,

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -329,7 +329,8 @@ class _QueryState:
         tool_use_id_str = str(tool_use_id) if tool_use_id is not None else None
 
         if msg_cls == "TaskStartedMessage":
-            if tool_use_id_str in self.tasks:
+            existing = self.tasks.get(tool_use_id_str)
+            if existing and not existing.ended:
                 return
             # Find parent: the Agent tool span if it exists
             parent_ctx = self.query_ctx

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -181,6 +181,37 @@ class _QueryState:
         self.tool_use_to_parent: dict[str, str | None] = {}
         # Maps Agent tool_use_id → subagent tool_use_id (they differ)
         self.agent_tool_to_subagent: dict[str, str] = {}
+        # Dedup: maps raw SubagentStart tool_use_id → canonical tool_use_id
+        self.raw_subagent_to_canonical: dict[str, str] = {}
+
+    def _canonical_subagent_id(self, raw_id: str, agent_id: str | None = None) -> str:
+        """Map a SubagentStart tool_use_id to a canonical ID, deduplicating
+        multiple sub-sub-agents onto the same parent Agent tool span.
+        Mirrors TS SDK's canonicalSubagentToolUseId()."""
+        existing = self.raw_subagent_to_canonical.get(raw_id)
+        if existing:
+            return existing
+
+        # Direct match in tools
+        if raw_id in self.tools:
+            self.raw_subagent_to_canonical[raw_id] = raw_id
+            return raw_id
+
+        # Map via agent_id → existing tool_use_id
+        if agent_id:
+            mapped = self.agent_id_to_tool_use_id.get(agent_id)
+            if mapped:
+                self.raw_subagent_to_canonical[raw_id] = mapped
+                return mapped
+
+        # Find the most recent unlinked Agent tool
+        for t in reversed(list(self.tools.values())):
+            if t.name == "Agent" and not t.has_subagent:
+                self.raw_subagent_to_canonical[raw_id] = t.tool_use_id
+                return t.tool_use_id
+
+        self.raw_subagent_to_canonical[raw_id] = raw_id
+        return raw_id
 
     # -- LLM span management --
 
@@ -411,13 +442,26 @@ def _create_hooks(state: _QueryState) -> dict[str, list[Any]]:
     async def subagent_start(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
         agent_id = input_data.get("agent_id", "")
         agent_type = input_data.get("agent_type", "")
-        tuid = tool_use_id or ""
-        if not tuid:
+        raw_tuid = tool_use_id or ""
+        if not raw_tuid:
             return {}
 
-        # Find the Agent tool span to parent under.
-        # SubagentStart's tool_use_id differs from the Agent tool's tool_use_id,
-        # so find the most recent unlinked Agent tool and map them.
+        # Deduplicate: map raw tool_use_id to canonical ID so multiple
+        # sub-sub-agents reuse the same Subagent span (matches TS SDK).
+        tuid = state._canonical_subagent_id(raw_tuid, agent_id)
+
+        # If subagent already exists for this canonical ID, just update mapping
+        existing = state.subagents.get(tuid)
+        if existing:
+            if agent_id:
+                existing.agent_id = agent_id
+                state.agent_id_to_tool_use_id[agent_id] = tuid
+                existing.span.set_attribute(CLAUDE_AGENT_AGENT_ID, agent_id)
+            if agent_type:
+                existing.span.set_attribute(CLAUDE_AGENT_AGENT_TYPE, agent_type)
+            return {}
+
+        # Find the Agent tool span to parent under
         tool = state.tools.get(tuid)
         if not tool:
             for t in reversed(list(state.tools.values())):
@@ -451,7 +495,8 @@ def _create_hooks(state: _QueryState) -> dict[str, list[Any]]:
         return {}
 
     async def subagent_stop(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
-        tuid = tool_use_id or ""
+        raw_tuid = tool_use_id or ""
+        tuid = state._canonical_subagent_id(raw_tuid, input_data.get("agent_id"))
         sub = state.subagents.get(tuid)
         if not sub or sub.ended:
             return {}

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -129,6 +129,7 @@ def _msg_type(message: Any) -> str:
 # Tool & subagent state
 # ---------------------------------------------------------------------------
 
+
 class _ToolState:
     __slots__ = ("ctx", "has_subagent", "name", "span", "tool_use_id")
 
@@ -154,6 +155,7 @@ class _SubagentState:
 # ---------------------------------------------------------------------------
 # Query state — tracks everything for a single query() call
 # ---------------------------------------------------------------------------
+
 
 class _QueryState:
     def __init__(
@@ -210,6 +212,7 @@ class _QueryState:
         parent_ctx = self._get_llm_parent_ctx(parent_tool_use_id)
 
         import time as _time
+
         start = self.pending_start_time or _time.time()
         span = self.tracer.start_span(
             LLM_SPAN_NAME,
@@ -273,6 +276,7 @@ class _QueryState:
 
         if msg_type == "assistant":
             import time as _time
+
             message_id = getattr(message, "message_id", None)
             if message_id and message_id != self.current_message_id:
                 self.flush_pending_llm()
@@ -315,6 +319,7 @@ class _QueryState:
 # ---------------------------------------------------------------------------
 # Hook creation — injected into query options
 # ---------------------------------------------------------------------------
+
 
 def _create_hooks(state: _QueryState) -> dict[str, list[Any]]:
     from claude_agent_sdk.types import HookMatcher
@@ -385,7 +390,9 @@ def _create_hooks(state: _QueryState) -> dict[str, list[Any]]:
             sub.ended = True
         return {}
 
-    async def post_tool_use_failure(input_data: dict[str, Any], tool_use_id: str | None, ctx: Any) -> dict:
+    async def post_tool_use_failure(
+        input_data: dict[str, Any], tool_use_id: str | None, ctx: Any
+    ) -> dict:
         tuid = tool_use_id or input_data.get("tool_use_id", "")
         error_msg = input_data.get("error", "Tool failed")
         tool = state.tools.pop(tuid, None)
@@ -471,6 +478,7 @@ def _create_hooks(state: _QueryState) -> dict[str, list[Any]]:
 # Hook merging
 # ---------------------------------------------------------------------------
 
+
 def _merge_hooks(
     options: Any | None,
     tracing_hooks: dict[str, list[dict[str, Any]]],
@@ -485,6 +493,7 @@ def _merge_hooks(
 # ---------------------------------------------------------------------------
 # Main wrapper
 # ---------------------------------------------------------------------------
+
 
 def wrap_query(original: Any, tracer_provider: Any = None) -> Any:
     """Wrap claude_agent_sdk.query() with OTel tracing."""
@@ -513,7 +522,9 @@ def wrap_query(original: Any, tracer_provider: Any = None) -> Any:
             query_span.set_attribute(CLAUDE_AGENT_MODEL, model)
 
         query_ctx = trace.set_span_in_context(query_span, parent_ctx)
-        state = _QueryState(tracer, query_span, query_ctx, prompt if isinstance(prompt, str) else None)
+        state = _QueryState(
+            tracer, query_span, query_ctx, prompt if isinstance(prompt, str) else None
+        )
 
         # Inject tracing hooks into options
         hooks = _create_hooks(state)
@@ -522,6 +533,7 @@ def wrap_query(original: Any, tracer_provider: Any = None) -> Any:
         import dataclasses
 
         from claude_agent_sdk.types import ClaudeAgentOptions as _Opts
+
         if options is not None and dataclasses.is_dataclass(options):
             modified_options = dataclasses.replace(options, hooks=merged_hooks)
         else:
@@ -531,7 +543,9 @@ def wrap_query(original: Any, tracer_provider: Any = None) -> Any:
         try:
             token = otel_context.attach(query_ctx)
             try:
-                async for message in original(prompt=prompt, options=modified_options, transport=transport):
+                async for message in original(
+                    prompt=prompt, options=modified_options, transport=transport
+                ):
                     state.process_message(message)
                     yield message
             finally:

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -128,10 +128,6 @@ def _msg_type(message: Any) -> str:
     return name.lower()
 
 
-def _msg_subtype(message: Any) -> str | None:
-    return getattr(message, "subtype", None)
-
-
 # ---------------------------------------------------------------------------
 # Active span tracking
 # ---------------------------------------------------------------------------
@@ -179,12 +175,17 @@ class _QueryState:
         self.current_message_id: str | None = None
         self.pending_messages: list[Any] = []
         self.pending_start_time: float | None = None
-        self.accumulated_output_tokens = 0
+        # One open LLM span per agent context, keyed by the spawning tool's id
+        # (the root/top-level turn uses the None key); held open so the final
+        # ResultMessage usage can be recorded on the root turn's span.
+        self.open_llm_spans: dict[str | None, trace.Span] = {}
 
         # Tool spans: tool_use_id → _ToolSpan
         self.active_tools: dict[str, _ToolSpan] = {}
         # Preserve Agent tool contexts after they close, for parenting task spans
         self.agent_tool_contexts: dict[str, otel_context.Context] = {}
+        # tool_use_id → subagent role (e.g. "researcher"), used as the task span name.
+        self.subagent_names: dict[str, str] = {}
 
         # Task spans: tool_use_id → _TaskSpan (from SystemMessage TaskStarted)
         self.tasks: dict[str | None, _TaskSpan] = {}
@@ -193,10 +194,14 @@ class _QueryState:
     # -- LLM parent resolution --
 
     def _get_task_parent_ctx(self, parent_tool_use_id: str | None) -> otel_context.Context:
-        """Find the task span context for a given parent_tool_use_id."""
-        if parent_tool_use_id is not None and parent_tool_use_id in self.tasks:
+        """Parent context for a message's parent_tool_use_id."""
+        # Orchestrator turns (None) parent under the query, not the active subagent
+        # task — otherwise sibling subagents nest inside each other.
+        if parent_tool_use_id is None:
+            return self.query_ctx
+        if parent_tool_use_id in self.tasks:
             return self.tasks[parent_tool_use_id].ctx
-        # Walk task_order in reverse to find the most recent active task
+        # Subagent message before its task span exists: most recent active task, else query.
         for key in reversed(self.task_order):
             task = self.tasks.get(key)
             if task and not task.ended:
@@ -216,11 +221,18 @@ class _QueryState:
         parent_ctx = self._get_task_parent_ctx(parent_tool_use_id)
 
         start = self.pending_start_time or time.time()
+        start_ns = int(start * 1e9)
+
+        # Tile: close this context's previous open span at the new turn's start.
+        prev = self.open_llm_spans.pop(parent_tool_use_id, None)
+        if prev is not None:
+            prev.end(end_time=start_ns)
+
         span = self.tracer.start_span(
             LLM_SPAN_NAME,
             attributes={OI_SPAN_KIND: "LLM"},
             context=parent_ctx,
-            start_time=int(start * 1e9),
+            start_time=start_ns,
         )
 
         model = getattr(last, "model", None)
@@ -230,7 +242,8 @@ class _QueryState:
                 if model:
                     break
         _set_model(span, model)
-        _set_usage_attrs(span, getattr(last, "usage", None))
+        # No per-turn usage: streamed counts are unreliable. The ResultMessage total
+        # is attached to the orchestrator span in process_message().
 
         if not parent_tool_use_id and self.prompt:
             val = _try_json([{"role": "user", "content": self.prompt}])
@@ -248,10 +261,9 @@ class _QueryState:
                 span.set_attribute(OI_OUTPUT_VALUE, val)
 
         span.set_status(StatusCode.OK)
-        span.end()
+        # Keep open; closed on the next flush of this context or in end_all().
+        self.open_llm_spans[parent_tool_use_id] = span
 
-        usage = getattr(last, "usage", None) or {}
-        self.accumulated_output_tokens += usage.get("output_tokens", 0)
         self.pending_messages = []
         self.pending_start_time = None
 
@@ -293,9 +305,10 @@ class _QueryState:
             # so we just save the context for future task spans.
             if tool_name == "Agent":
                 self.agent_tool_contexts[tool_use_id] = tool_ctx
-                # If a task span exists for this tool_use_id, it was created
-                # before the Agent tool span (with query as parent). We can't
-                # reparent, but this is the expected timing issue.
+                if isinstance(tool_input, dict):
+                    role = tool_input.get("subagent_type") or tool_input.get("name")
+                    if role:
+                        self.subagent_names[tool_use_id] = str(role)
 
     def _finish_tool_spans_from_message(self, message: Any) -> None:
         """End tool spans from tool_result blocks in a UserMessage."""
@@ -329,16 +342,41 @@ class _QueryState:
     # -- Task span management (from SystemMessage) --
 
     def _handle_task_event(self, message: Any) -> None:
-        """Create/update/end task spans from TaskStarted/TaskNotification."""
+        """Create/update/end subagent task spans from task system messages.
+
+        Created on the first task event of any type (incl. TaskProgress, so a subagent
+        that never emits TaskStarted still gets a span), keyed by tool_use_id and
+        parented under the spawning tool span; ended on TaskNotification.
+        """
         msg_cls = type(message).__name__
+        if msg_cls not in (
+            "TaskStartedMessage",
+            "TaskProgressMessage",
+            "TaskNotificationMessage",
+        ):
+            return
+
         tool_use_id = getattr(message, "tool_use_id", None)
         tool_use_id_str = str(tool_use_id) if tool_use_id is not None else None
+        task_id = getattr(message, "task_id", None)
+        # Key by tool_use_id (links to the spawning tool span); fall back to task_id.
+        key = (
+            tool_use_id_str
+            if tool_use_id_str is not None
+            else (str(task_id) if task_id is not None else None)
+        )
+        if key is None:
+            return
 
-        if msg_cls == "TaskStartedMessage":
-            existing = self.tasks.get(tool_use_id_str)
-            if existing and not existing.ended:
-                return
-            # Find parent: the Agent tool span (active or closed)
+        description = getattr(message, "description", None)
+        task_type = getattr(message, "task_type", None)
+        # Low-cardinality span name: the subagent role, else the task type, else generic.
+        # The free-text description is kept as an attribute, not as the span name.
+        span_name = self.subagent_names.get(key) or (str(task_type) if task_type else "subagent")
+
+        task = self.tasks.get(key)
+        if task is None:
+            # Parent under the spawning tool span (Agent/Skill/Workflow) if known.
             parent_ctx = self.query_ctx
             if tool_use_id_str:
                 if tool_use_id_str in self.active_tools:
@@ -346,28 +384,28 @@ class _QueryState:
                 elif tool_use_id_str in self.agent_tool_contexts:
                     parent_ctx = self.agent_tool_contexts[tool_use_id_str]
 
-            description = getattr(message, "description", None)
-            task_type = getattr(message, "task_type", None)
-            span_name = (
-                str(description) if description else (str(task_type) if task_type else "Task")
-            )
-
             task_span = self.tracer.start_span(
                 span_name,
                 attributes={OI_SPAN_KIND: "AGENT", CLAUDE_AGENT_TOOL_USE_ID: tool_use_id_str or ""},
                 context=parent_ctx,
             )
+            if description:
+                task_span.set_attribute(OI_INPUT_VALUE, str(description))
             task_ctx = trace.set_span_in_context(task_span, parent_ctx)
-            self.tasks[tool_use_id_str] = _TaskSpan(task_span, task_ctx, tool_use_id_str)
-            self.task_order.append(tool_use_id_str)
+            task = _TaskSpan(task_span, task_ctx, tool_use_id_str)
+            self.tasks[key] = task
+            self.task_order.append(key)
+        elif not task.ended:
+            # Update to the role once the spawning Agent tool reveals it (rare ordering).
+            role = self.subagent_names.get(key)
+            if role:
+                task.span.update_name(role)
 
-        elif msg_cls == "TaskNotificationMessage":
-            task = self.tasks.get(tool_use_id_str)
-            if task and not task.ended:
-                task.span.set_status(StatusCode.OK)
-                task.span.end()
-                task.ended = True
-                self.task_order = [k for k in self.task_order if k != tool_use_id_str]
+        if msg_cls == "TaskNotificationMessage" and not task.ended:
+            task.span.set_status(StatusCode.OK)
+            task.span.end()
+            task.ended = True
+            self.task_order = [k for k in self.task_order if k != key]
 
     # -- Message processing --
 
@@ -394,6 +432,12 @@ class _QueryState:
 
         elif msg_type == "result":
             self.flush_pending_llm()
+            # Attach the ResultMessage usage to the orchestrator (None) span only;
+            # subagent turns stay empty (sparse).
+            result_usage = getattr(message, "usage", None)
+            orchestrator_span = self.open_llm_spans.get(None)
+            if orchestrator_span is not None and result_usage:
+                _set_usage_attrs(orchestrator_span, result_usage)
             result = getattr(message, "result", None)
             if isinstance(result, str):
                 self.query_span.set_attribute(OI_OUTPUT_VALUE, result)
@@ -414,6 +458,11 @@ class _QueryState:
 
     def end_all(self, status: StatusCode = StatusCode.OK, error: str | None = None) -> None:
         self.flush_pending_llm()
+        for span in self.open_llm_spans.values():
+            if error is not None:
+                span.set_status(status, error)
+            span.end()
+        self.open_llm_spans.clear()
         for tool in self.active_tools.values():
             tool.span.set_status(status, error)
             tool.span.end()

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -183,6 +183,8 @@ class _QueryState:
 
         # Tool spans: tool_use_id → _ToolSpan
         self.active_tools: dict[str, _ToolSpan] = {}
+        # Preserve Agent tool contexts after they close, for parenting task spans
+        self.agent_tool_contexts: dict[str, otel_context.Context] = {}
 
         # Task spans: tool_use_id → _TaskSpan (from SystemMessage TaskStarted)
         self.tasks: dict[str | None, _TaskSpan] = {}
@@ -245,11 +247,6 @@ class _QueryState:
             if val:
                 span.set_attribute(OI_OUTPUT_VALUE, val)
 
-        # Create tool spans from tool_use blocks
-        llm_ctx = trace.set_span_in_context(span, parent_ctx)
-        for msg in self.pending_messages:
-            self._start_tool_spans_from_message(msg, llm_ctx)
-
         span.set_status(StatusCode.OK)
         span.end()
 
@@ -290,6 +287,15 @@ class _QueryState:
 
             tool_ctx = trace.set_span_in_context(tool_span, llm_ctx)
             self.active_tools[tool_use_id] = _ToolSpan(tool_span, tool_ctx, tool_name, tool_use_id)
+
+            # For Agent tools, check if a task span was already created (TaskStartedMessage
+            # arrives before AssistantMessage). If so, reparent won't work in OTel,
+            # so we just save the context for future task spans.
+            if tool_name == "Agent":
+                self.agent_tool_contexts[tool_use_id] = tool_ctx
+                # If a task span exists for this tool_use_id, it was created
+                # before the Agent tool span (with query as parent). We can't
+                # reparent, but this is the expected timing issue.
 
     def _finish_tool_spans_from_message(self, message: Any) -> None:
         """End tool spans from tool_result blocks in a UserMessage."""
@@ -332,10 +338,13 @@ class _QueryState:
             existing = self.tasks.get(tool_use_id_str)
             if existing and not existing.ended:
                 return
-            # Find parent: the Agent tool span if it exists
+            # Find parent: the Agent tool span (active or closed)
             parent_ctx = self.query_ctx
-            if tool_use_id_str and tool_use_id_str in self.active_tools:
-                parent_ctx = self.active_tools[tool_use_id_str].ctx
+            if tool_use_id_str:
+                if tool_use_id_str in self.active_tools:
+                    parent_ctx = self.active_tools[tool_use_id_str].ctx
+                elif tool_use_id_str in self.agent_tool_contexts:
+                    parent_ctx = self.agent_tool_contexts[tool_use_id_str]
 
             description = getattr(message, "description", None)
             task_type = getattr(message, "task_type", None)
@@ -373,6 +382,9 @@ class _QueryState:
             if not self.pending_messages:
                 self.pending_start_time = time.time()
             self.pending_messages.append(message)
+            # Create tool spans immediately (not waiting for flush) so that
+            # TaskStartedMessage can find the Agent tool span as parent.
+            self._start_tool_spans_from_message(message, self.query_ctx)
 
         elif msg_type == "user":
             self.flush_pending_llm()

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -15,7 +15,8 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
-from opentelemetry import context as otel_context, trace
+from opentelemetry import context as otel_context
+from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 
 logger = logging.getLogger(__name__)
@@ -129,7 +130,7 @@ def _msg_type(message: Any) -> str:
 # ---------------------------------------------------------------------------
 
 class _ToolState:
-    __slots__ = ("span", "ctx", "name", "tool_use_id", "has_subagent")
+    __slots__ = ("ctx", "has_subagent", "name", "span", "tool_use_id")
 
     def __init__(self, span: trace.Span, ctx: otel_context.Context, name: str, tool_use_id: str):
         self.span = span
@@ -140,7 +141,7 @@ class _ToolState:
 
 
 class _SubagentState:
-    __slots__ = ("span", "ctx", "tool_use_id", "agent_id", "ended")
+    __slots__ = ("agent_id", "ctx", "ended", "span", "tool_use_id")
 
     def __init__(self, span: trace.Span, ctx: otel_context.Context, tool_use_id: str):
         self.span = span
@@ -513,7 +514,8 @@ def wrap_query(original: Any) -> Any:
         hooks = _create_hooks(state)
         merged_hooks = _merge_hooks(options, hooks)
 
-        import dataclasses
+        import dataclasses  # noqa: I001
+
         from claude_agent_sdk.types import ClaudeAgentOptions as _Opts
         if options is not None and dataclasses.is_dataclass(options):
             modified_options = dataclasses.replace(options, hooks=merged_hooks)

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -180,7 +180,7 @@ def initialize_integrations(
             try:
                 from traceroot.instrumentation.claude_agent_sdk import instrument_claude_agent_sdk
 
-                instrument_claude_agent_sdk()
+                instrument_claude_agent_sdk(tracer_provider)
                 logger.info("Instrumented %s via in-house wrapper", instrument.value)
                 instrumented.append(instrument)
             except Exception:

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -181,10 +181,10 @@ def initialize_integrations(
                 from traceroot.instrumentation.claude_agent_sdk import instrument_claude_agent_sdk
 
                 instrument_claude_agent_sdk()
-                logger.info("Instrumented %s via in-house wrapper", library)
+                logger.info("Instrumented %s via in-house wrapper", instrument.value)
                 instrumented.append(instrument)
             except Exception:
-                logger.warning("Failed to instrument %s", library, exc_info=True)
+                logger.warning("Failed to instrument %s", instrument.value, exc_info=True)
             continue
 
         try:

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -175,6 +175,18 @@ def initialize_integrations(
             )
             continue
 
+        # In-house instrumentation for Claude Agent SDK (replaces OpenInference)
+        if instrument is Integration.CLAUDE_AGENT_SDK:
+            try:
+                from traceroot.instrumentation.claude_agent_sdk import instrument_claude_agent_sdk
+
+                instrument_claude_agent_sdk()
+                logger.info("Instrumented %s via in-house wrapper", library)
+                instrumented.append(instrument)
+            except Exception:
+                logger.warning("Failed to instrument %s", library, exc_info=True)
+            continue
+
         try:
             module = importlib.import_module(entry.module_path)
             instrumentor_cls = getattr(module, entry.class_name)


### PR DESCRIPTION
 ## Summary
  
 Replace OpenInference `ClaudeAgentSDKInstrumentor` with a custom message-driven wrapper around `claude_agent_sdk.query()`. Creates proper OTel spans with accurate token metrics and lean trace structure. References TraceRoot TS SDK (PR #97).

  ## What Changed
  
  - **New**: `traceroot/instrumentation/claude_agent_sdk.py` (~490 lines)
  - **Modified**: `traceroot/instrumentation/registry.py` — routes `Integration.CLAUDE_AGENT_SDK` to in-house wrapper

  ## How It Works
  
  Pure message-driven approach (no hooks injected), parsing `query()` message stream:
  
  - **`AssistantMessage`** → `anthropic.messages.create` LLM spans with model name, token counts (including cache read/creation)
  - **`AssistantMessage` ToolUseBlock** → Tool span start (WebSearch, Bash, Agent, etc.)
  - **`UserMessage` ToolResultBlock** → Tool span end with output
  - **`SystemMessage` TaskStarted/TaskNotification** → Task spans with meaningful names (e.g., "Research what MCP is")
  - **`ResultMessage`** → cost/turns metadata on query span 
  - **Nesting**: `Agent tool → task span → LLM + tools` 
  
  ## Before vs After
  
  | | Before (OpenInference) | After (Message-driven) |
  |---|---|---|
  | LLM spans | None | `anthropic.messages.create` per LLM call |
  | Token count | 5.4K (inaccurate) | ~20K-90K per call (accurate, incl. cache) |
  | Tool spans | Flat siblings | Nested under task spans |
  | Task naming | Generic `ClaudeAgentSDK.Agent` | Meaningful names from TaskStartedMessage |
  | Cache metrics | Not tracked | cache_read + cache_creation |
  | Model visibility | Not shown | Model name on each LLM span |
  | Span count (complex) | ~1,200 (hook explosion) | ~20-40 (message-driven dedup) |
  
  ## ScreenShots
https://github.com/user-attachments/assets/eaa9493f-60b5-4e03-addd-73324672c459

https://github.com/user-attachments/assets/00faacc2-5db4-439a-93a4-3236f69d9294