### PR TITLE
feat(instrumentation): add AWS Bedrock SDK integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "openinference-instrumentation-autogen>=0.1.10,<1.0",
     "openinference-instrumentation-google-adk>=0.1.10,<1.0",
     "openinference-instrumentation-pydantic-ai>=0.1.15,<1.0",
+    "openinference-instrumentation-bedrock>=0.1.41,<1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_auto_instrumentation.py
+++ b/tests/test_auto_instrumentation.py
@@ -29,6 +29,7 @@ def test_integration_enum_values():
     assert Integration.LLAMA_INDEX == "llama_index"
     assert Integration.DSPY == "dspy"
     assert Integration.PYDANTIC_AI == "pydantic_ai"
+    assert Integration.BEDROCK == "bedrock"
 
 
 def test_integration_exported_from_traceroot():
@@ -629,3 +630,50 @@ def test_pydantic_ai_can_be_requested_with_other_integrations(mock_installed):
     mock_openai_instrumentor.instrument.assert_called_once_with(tracer_provider=provider)
     provider.add_span_processor.assert_called_once_with(mock_oi_processor)
     mock_agent_cls.instrument_all.assert_called_once_with()
+
+
+# =============================================================================
+# Bedrock integration
+# =============================================================================
+
+
+def test_bedrock_integration_enum_value():
+    assert Integration.BEDROCK == "bedrock"
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_bedrock_integration_uses_bedrock_instrumentor(mock_installed):
+    mock_installed.return_value = True
+    mock_instrumentor = MagicMock()
+    mock_cls = MagicMock(return_value=mock_instrumentor)
+    mock_module = MagicMock()
+    mock_module.BedrockInstrumentor = mock_cls
+
+    provider = TracerProvider()
+
+    with patch("importlib.import_module", return_value=mock_module):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.BEDROCK],
+        )
+
+    assert result == [Integration.BEDROCK]
+    mock_instrumentor.instrument.assert_called_once_with(tracer_provider=provider)
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_bedrock_missing_warns_and_skips(mock_installed, caplog):
+    import logging
+
+    mock_installed.return_value = False
+
+    provider = TracerProvider()
+    with caplog.at_level(logging.WARNING, logger="traceroot.instrumentation.registry"):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.BEDROCK],
+        )
+
+    assert result == []
+    assert "skipping" in caplog.text
+    assert "boto3" in caplog.text

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -34,6 +34,7 @@ class Integration(StrEnum):
     GOOGLE_ADK = "google_adk"
     MISTRAL = "mistral"
     PYDANTIC_AI = "pydantic_ai"
+    BEDROCK = "bedrock"
 
 
 @dataclass
@@ -128,6 +129,11 @@ _BUILTIN_REGISTRY: dict[Integration, InstrumentorEntry] = {
         alt_packages=("pydantic-ai-slim",),
         module_path="traceroot.instrumentation._instrumentors",
         class_name="PydanticAIInstrumentor",
+    ),
+    Integration.BEDROCK: InstrumentorEntry(
+        package="boto3",
+        module_path="openinference.instrumentation.bedrock",
+        class_name="BedrockInstrumentor",
     ),
 }
 


### PR DESCRIPTION
closes the python side of traceroot-ai/traceroot#737.

the typescript bedrock example already landed (examples/typescript/bedrock). the python sdk was the remaining gap, flagged in the issue thread. this wires aws bedrock auto-instrumentation into traceroot-py following the existing registry pattern.

what changed:
- `registry.py`: add `Integration.BEDROCK` and a `_BUILTIN_REGISTRY` entry pointing at `openinference.instrumentation.bedrock` (`BedrockInstrumentor`), with `boto3` as the install-check package
- `pyproject.toml`: add `openinference-instrumentation-bedrock>=0.1.41,<1.0` to core dependencies
- `tests`: 3 new tests matching the existing per-integration pattern (enum value, instruments when boto3 present, warns + skips when boto3 missing)

on the dependency placement: the issue suggested an optional `[bedrock]` extra that bundles boto3. i went with a core dependency and no bundled boto3 instead, to match how the other 14 integrations work here. they all ship the lightweight openinference shim as a core dep and let the user bring the real sdk, with the registry skipping gracefully if it is not installed. the bedrock shim itself only declares boto3 as an optional extra, so this keeps things consistent. dspy is the one exception and it is opt-in because it bundles the heavy dspy runtime. happy to switch to the extra if you intended bedrock to follow the dspy pattern.

left `uv.lock` untouched on purpose. the committed lock is already behind pyproject (missing mistral, groq and others), CI runs `uv sync --dev` so it resolves fresh, and none of the prior integration PRs touched it. didn't want to drag a full lock reconcile into this change. glad to regenerate it in a separate PR if you want the lock caught up.

how it was tested:
- full suite green (175 passed) with `uv run pytest`
- ruff clean
- real end-to-end check with boto3 installed: `initialize_integrations([Integration.BEDROCK])` imports the real instrumentor and instruments boto3, returns `[Integration.BEDROCK]`. not just the mocked unit tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS Bedrock auto-instrumentation using the existing registry pattern. Introduces `Integration.BEDROCK` to enable tracing of `boto3` Bedrock calls.

- **New Features**
  - Added `Integration.BEDROCK` that loads `openinference.instrumentation.bedrock.BedrockInstrumentor` when `boto3` is installed.
  - Tests cover enum value, successful instrumentation with `boto3`, and warn/skip behavior when `boto3` is missing.

- **Dependencies**
  - Added `openinference-instrumentation-bedrock>=0.1.41,<1.0` to core dependencies; `boto3` is user-provided and optional.

<sup>Written for commit c0427c663507fe1ece1023a4de9944d65b3e46b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

