### PR TITLE
feat(instrumentation): trace ClaudeSDKClient persistent streaming client

### DIFF
--- a/tests/test_claude_agent_sdk.py
+++ b/tests/test_claude_agent_sdk.py
@@ -556,7 +556,9 @@ async def test_client_error_in_stream_marks_span_error_and_propagates():
         raise ValueError("boom")
 
     cls = _wrap_fake_client(provider, receive=receive_then_raise)
-    msgs = [AssistantMessage([TextBlock("a")], model="m", message_id="m1", usage={"input_tokens": 1})]
+    msgs = [
+        AssistantMessage([TextBlock("a")], model="m", message_id="m1", usage={"input_tokens": 1})
+    ]
     client = cls(options=None, msgs=msgs)
     await client.query("hello")
     with pytest.raises(ValueError, match="boom"):

--- a/tests/test_claude_agent_sdk.py
+++ b/tests/test_claude_agent_sdk.py
@@ -12,12 +12,14 @@ emits (the instrumentor dispatches on ``type(message).__name__``).
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from traceroot.instrumentation.claude_agent_sdk import wrap_query
+from traceroot.instrumentation.claude_agent_sdk import wrap_client, wrap_query
 
 LLM_COMPLETION = "llm.token_count.completion"
 LLM_PROMPT = "llm.token_count.prompt"
@@ -365,3 +367,220 @@ async def test_all_spans_share_single_root():
     roots = [s for s in spans if s.parent is None or s.parent.span_id not in ids]
     assert len(roots) == 1, f"expected exactly 1 root, got {len(roots)}: {[s.name for s in roots]}"
     assert roots[0].name == "ClaudeAgent.query"
+
+
+# --- ClaudeSDKClient (persistent streaming client) path ---------------------
+
+
+def _make_fake_client_cls(receive=None, query=None):
+    """A stand-in for ClaudeSDKClient: query() stashes the prompt, and
+    receive_response() replays the instance's preset message list.
+
+    ``receive`` / ``query`` override those methods to simulate errors,
+    cancellation, or non-string prompts.
+    """
+
+    class FakeClient:
+        def __init__(self, options=None, msgs=None):
+            self.options = options
+            self._msgs = msgs or []
+            self.disconnected = False
+
+        async def disconnect(self):
+            self.disconnected = True
+
+    if query is None:
+
+        async def _default_query(self, prompt, session_id="default"):
+            self._last_prompt = prompt
+
+        FakeClient.query = _default_query
+    else:
+        FakeClient.query = query
+
+    if receive is None:
+
+        async def _default_receive(self):
+            for m in self._msgs:
+                yield m
+
+        FakeClient.receive_response = _default_receive
+    else:
+        FakeClient.receive_response = receive
+
+    return FakeClient
+
+
+def _wrap_fake_client(provider, receive=None, query=None):
+    cls = _make_fake_client_cls(receive=receive, query=query)
+    wq, wr, wd = wrap_client(cls, provider)
+    cls.query, cls.receive_response, cls.disconnect = wq, wr, wd
+    return cls
+
+
+@pytest.mark.asyncio
+async def test_client_turn_creates_root_and_llm_spans():
+    """A query()/receive_response() turn produces the same span shape as query():
+    one ClaudeAgent.query root with the LLM span nested under it."""
+    provider, exporter = _provider()
+    cls = _wrap_fake_client(provider)
+    messages = [
+        AssistantMessage(
+            [TextBlock("answer")],
+            model="claude-sonnet-4",
+            message_id="m1",
+            usage={"input_tokens": 10, "output_tokens": 5},
+        ),
+        ResultMessage(
+            result="done", usage={"input_tokens": 10, "output_tokens": 200}, total_cost_usd=0.5
+        ),
+    ]
+    client = cls(options=None, msgs=messages)
+    await client.query("hello")
+    async for _ in client.receive_response():
+        pass
+
+    spans = exporter.get_finished_spans()
+    roots = [s for s in spans if s.parent is None]
+    assert len(roots) == 1 and roots[0].name == "ClaudeAgent.query"
+    llm = _llm_spans(exporter)
+    assert llm, "expected an anthropic.messages.create LLM span on the client path"
+    total = sum((s.attributes.get(LLM_COMPLETION) or 0) for s in llm)
+    assert total == 200, f"expected 200 (ResultMessage total), got {total}"
+    # LLM span nests under the query root.
+    assert llm[0].parent is not None and llm[0].parent.span_id == roots[0].context.span_id
+
+
+@pytest.mark.asyncio
+async def test_client_multi_turn_creates_separate_roots():
+    """Each turn on a persistent client is its own root span."""
+    provider, exporter = _provider()
+    cls = _wrap_fake_client(provider)
+    messages = [
+        AssistantMessage([TextBlock("a")], model="m", message_id="m1", usage={"input_tokens": 1}),
+        ResultMessage(result="r", usage={"input_tokens": 1, "output_tokens": 2}),
+    ]
+    client = cls(options=None, msgs=messages)
+    for _ in range(2):
+        await client.query("hi")
+        async for _ in client.receive_response():
+            pass
+
+    roots = [s for s in exporter.get_finished_spans() if s.name == "ClaudeAgent.query"]
+    assert len(roots) == 2, f"expected 2 turn roots, got {len(roots)}"
+
+
+@pytest.mark.asyncio
+async def test_client_receive_without_query_is_passthrough():
+    """receive_response with no active turn yields messages untraced, no crash."""
+    provider, exporter = _provider()
+    cls = _wrap_fake_client(provider)
+    client = cls(options=None, msgs=[ResultMessage(result="r")])
+    got = [m async for m in client.receive_response()]
+    assert len(got) == 1
+    assert exporter.get_finished_spans() == ()
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_ends_dangling_turn():
+    """query() with no consumed response still has its span closed on disconnect()."""
+    provider, exporter = _provider()
+    cls = _wrap_fake_client(provider)
+    client = cls(options=None, msgs=[])
+    await client.query("hello")
+    assert exporter.get_finished_spans() == (), "span should still be open before disconnect"
+    await client.disconnect()
+    roots = [s for s in exporter.get_finished_spans() if s.name == "ClaudeAgent.query"]
+    assert len(roots) == 1, "disconnect must close the dangling turn span"
+    assert client.disconnected is True, "original disconnect must still run"
+
+
+@pytest.mark.asyncio
+async def test_client_cancelled_error_in_stream_is_suppressed():
+    """A CancelledError leaked by the subprocess transport (e.g. anyio cleanup
+    when subagents finish) ends the turn cleanly and is NOT propagated."""
+    provider, exporter = _provider()
+
+    async def receive_then_cancel(self):
+        for m in self._msgs:
+            yield m
+        raise asyncio.CancelledError()
+
+    cls = _wrap_fake_client(provider, receive=receive_then_cancel)
+    msgs = [
+        AssistantMessage([TextBlock("a")], model="m", message_id="m1", usage={"input_tokens": 1}),
+        ResultMessage(result="r", usage={"input_tokens": 1, "output_tokens": 2}),
+    ]
+    client = cls(options=None, msgs=msgs)
+    await client.query("hello")
+    got = [m async for m in client.receive_response()]  # must not raise
+    assert len(got) == 2
+    roots = [s for s in exporter.get_finished_spans() if s.name == "ClaudeAgent.query"]
+    assert len(roots) == 1, "turn span must still be closed after a suppressed cancel"
+    assert roots[0].status.status_code.name != "ERROR"
+
+
+@pytest.mark.asyncio
+async def test_client_async_iterable_prompt_is_handled():
+    """A non-string (AsyncIterable) prompt is accepted; the turn still traces and
+    no input.value is recorded for it."""
+    provider, exporter = _provider()
+    cls = _wrap_fake_client(provider)
+    msgs = [
+        AssistantMessage([TextBlock("a")], model="m", message_id="m1", usage={"input_tokens": 1}),
+        ResultMessage(result="r", usage={"input_tokens": 1, "output_tokens": 2}),
+    ]
+
+    async def prompt_stream():
+        yield {"type": "user", "message": {"role": "user", "content": "hi"}}
+
+    client = cls(options=None, msgs=msgs)
+    await client.query(prompt_stream())  # async iterable, not str
+    async for _ in client.receive_response():
+        pass
+
+    roots = [s for s in exporter.get_finished_spans() if s.name == "ClaudeAgent.query"]
+    assert len(roots) == 1
+    assert "input.value" not in (roots[0].attributes or {})
+    assert _llm_spans(exporter), "LLM span should still be produced for a streamed prompt"
+
+
+@pytest.mark.asyncio
+async def test_client_error_in_stream_marks_span_error_and_propagates():
+    """A genuine exception mid-stream is re-raised and the turn span is ERROR."""
+    provider, exporter = _provider()
+
+    async def receive_then_raise(self):
+        for m in self._msgs:
+            yield m
+        raise ValueError("boom")
+
+    cls = _wrap_fake_client(provider, receive=receive_then_raise)
+    msgs = [AssistantMessage([TextBlock("a")], model="m", message_id="m1", usage={"input_tokens": 1})]
+    client = cls(options=None, msgs=msgs)
+    await client.query("hello")
+    with pytest.raises(ValueError, match="boom"):
+        async for _ in client.receive_response():
+            pass
+
+    roots = [s for s in exporter.get_finished_spans() if s.name == "ClaudeAgent.query"]
+    assert len(roots) == 1
+    assert roots[0].status.status_code.name == "ERROR"
+
+
+@pytest.mark.asyncio
+async def test_client_query_send_error_marks_span_error_and_propagates():
+    """If query() (send) raises, the turn span is closed as ERROR and the error propagates."""
+    provider, exporter = _provider()
+
+    async def query_raises(self, prompt, session_id="default"):
+        raise RuntimeError("send failed")
+
+    cls = _wrap_fake_client(provider, query=query_raises)
+    client = cls(options=None, msgs=[])
+    with pytest.raises(RuntimeError, match="send failed"):
+        await client.query("hello")
+
+    roots = [s for s in exporter.get_finished_spans() if s.name == "ClaudeAgent.query"]
+    assert len(roots) == 1
+    assert roots[0].status.status_code.name == "ERROR"

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -13,11 +13,13 @@ Uses a message-driven approach rather than hooks:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
 from collections.abc import AsyncIterator
 from typing import Any
+from weakref import WeakKeyDictionary
 
 from opentelemetry import context as otel_context
 from opentelemetry import trace
@@ -546,6 +548,131 @@ def wrap_query(original: Any, tracer_provider: Any = None) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Persistent streaming client (ClaudeSDKClient)
+# ---------------------------------------------------------------------------
+#
+# Unlike query(), which is a single async generator, the client splits one turn
+# across separate calls: query() sends the prompt, receive_response() consumes
+# the message stream. The _QueryState message engine is reused unchanged; only
+# the orchestration differs. State must live on the client *instance* (not a
+# closure) because send and receive are distinct calls, so we key it by instance
+# in a WeakKeyDictionary. Each query()/receive_response() turn gets its own root
+# span, mirroring wrap_query's per-request structure.
+
+# client instance -> active turn state (one in-flight turn per client)
+_CLIENT_STATES: WeakKeyDictionary[Any, _QueryState] = WeakKeyDictionary()
+
+
+def _end_client_turn(client: Any, error: Exception | None = None) -> None:
+    state = _CLIENT_STATES.pop(client, None)
+    if state is None:
+        return
+    if error is not None:
+        state.end_all(StatusCode.ERROR, str(error))
+        state.query_span.set_status(StatusCode.ERROR, str(error))
+        state.query_span.record_exception(error)
+    else:
+        state.end_all(StatusCode.OK)
+        state.query_span.set_status(StatusCode.OK)
+    state.query_span.end()
+
+
+def _safe_end_client_turn(client: Any, error: Exception | None = None) -> None:
+    # Teardown must never raise into the user's code path.
+    try:
+        _end_client_turn(client, error)
+    except Exception:
+        logger.warning("traceroot: failed to end claude_agent_sdk client turn", exc_info=True)
+
+
+def wrap_client(client_cls: Any, tracer_provider: Any = None) -> tuple[Any, Any, Any]:
+    """Build tracing wrappers for ClaudeSDKClient.query/receive_response/disconnect.
+
+    Returns ``(wrapped_query, wrapped_receive_response, wrapped_disconnect)``.
+    """
+    if tracer_provider is not None:
+        tracer = tracer_provider.get_tracer(TRACER_NAME)
+    else:
+        tracer = trace.get_tracer(TRACER_NAME)
+
+    orig_query = client_cls.query
+    orig_receive = client_cls.receive_response
+    orig_disconnect = client_cls.disconnect
+
+    async def wrapped_query(self: Any, prompt: Any, session_id: str = "default") -> None:
+        # Start a fresh turn. Defensively close any prior turn that never had its
+        # response consumed so its span is not leaked.
+        try:
+            _end_client_turn(self)
+            parent_ctx = otel_context.get_current()
+            query_span = tracer.start_span(
+                QUERY_SPAN_NAME,
+                attributes={OI_SPAN_KIND: "AGENT"},
+                context=parent_ctx,
+            )
+            if isinstance(prompt, str):
+                query_span.set_attribute(OI_INPUT_VALUE, prompt)
+            model = getattr(getattr(self, "options", None), "model", None)
+            if model:
+                query_span.set_attribute(CLAUDE_AGENT_MODEL, model)
+            query_ctx = trace.set_span_in_context(query_span, parent_ctx)
+            _CLIENT_STATES[self] = _QueryState(
+                tracer, query_span, query_ctx, prompt if isinstance(prompt, str) else None
+            )
+        except Exception:
+            logger.warning("traceroot: failed to start claude_agent_sdk client turn", exc_info=True)
+
+        try:
+            return await orig_query(self, prompt, session_id)
+        except Exception as exc:
+            _safe_end_client_turn(self, exc)
+            raise
+
+    async def wrapped_receive_response(self: Any) -> AsyncIterator[Any]:
+        state = _CLIENT_STATES.get(self)
+        if state is None:
+            # No active turn (e.g. receive_response without a preceding query) —
+            # pass through untraced rather than guess at a span.
+            async for message in orig_receive(self):
+                yield message
+            return
+
+        error: Exception | None = None
+        token = otel_context.attach(state.query_ctx)
+        try:
+            async for message in orig_receive(self):
+                try:
+                    state.process_message(message)
+                except Exception:
+                    logger.warning(
+                        "traceroot: failed to process claude_agent_sdk message",
+                        exc_info=True,
+                    )
+                yield message
+        except asyncio.CancelledError:
+            # The claude_agent_sdk subprocess transport (anyio) can raise
+            # CancelledError during normal cleanup — e.g. when subagents
+            # finish — rather than as a genuine external cancellation. End the
+            # turn cleanly and stop without propagating; a real caller
+            # cancellation still re-fires at the caller's next await point.
+            pass
+        except Exception as exc:
+            error = exc
+            raise
+        finally:
+            otel_context.detach(token)
+            _safe_end_client_turn(self, error)
+
+    async def wrapped_disconnect(self: Any) -> None:
+        # Covers explicit disconnect() and `async with` exit (__aexit__ calls
+        # disconnect). Close any turn whose stream was never fully consumed.
+        _safe_end_client_turn(self)
+        return await orig_disconnect(self)
+
+    return wrapped_query, wrapped_receive_response, wrapped_disconnect
+
+
+# ---------------------------------------------------------------------------
 # Public entry point — called by registry
 # ---------------------------------------------------------------------------
 
@@ -553,11 +680,23 @@ _WRAPPED = False
 
 
 def instrument_claude_agent_sdk(tracer_provider: Any = None) -> None:
-    """Monkey-patch claude_agent_sdk.query with tracing wrapper."""
+    """Monkey-patch claude_agent_sdk.query and the ClaudeSDKClient path."""
     global _WRAPPED
     if _WRAPPED:
         return
     import claude_agent_sdk
 
     claude_agent_sdk.query = wrap_query(claude_agent_sdk.query, tracer_provider)
+
+    # Persistent streaming client: wrap the send / receive / teardown methods so
+    # ClaudeSDKClient sessions are traced, not only the one-shot query() helper.
+    client_cls = getattr(claude_agent_sdk, "ClaudeSDKClient", None)
+    if client_cls is not None:
+        wrapped_query, wrapped_receive_response, wrapped_disconnect = wrap_client(
+            client_cls, tracer_provider
+        )
+        client_cls.query = wrapped_query
+        client_cls.receive_response = wrapped_receive_response
+        client_cls.disconnect = wrapped_disconnect
+
     _WRAPPED = True


### PR DESCRIPTION
Closes #129

## What

Extends the `claude_agent_sdk` instrumentation from the one-shot `query()` helper to the persistent **`ClaudeSDKClient`**. Multi-turn / interactive client sessions are now traced with the same span shape as the `query()` path: each `query()`→`receive_response()` turn produces its own `ClaudeAgent.query` root span, with LLM / tool / subagent spans nested under it.

## How

- New `wrap_client()` wraps `query` / `receive_response` / `disconnect`; wired up in `instrument_claude_agent_sdk()`.
- Reuses the existing `_QueryState` message engine **unchanged** — only the orchestration differs, because send (`query`) and receive (`receive_response`) are distinct calls. Turn state is keyed per client instance in a `WeakKeyDictionary`.
- Defensive lifecycle:
  - a new `query()` closes any prior un-consumed turn (no span leak),
  - `disconnect()` — and `async with` exit, which calls `disconnect()` — closes a dangling turn,
  - instrumentation failures are logged and degrade to untraced rather than breaking the caller,
  - a `CancelledError` surfaced by the SDK's subprocess transport during normal cleanup ends the turn cleanly without being propagated.
- `getattr`-guarded so SDK versions without `ClaudeSDKClient` are silently skipped.

No new dependencies — uses only stdlib (`asyncio`, `weakref`) plus OpenTelemetry already in use.

## Tests

Adds 8 tests for the client path (root + nested LLM span, separate roots per turn, untraced passthrough without a preceding query, dangling-turn close on disconnect, suppressed cancel, async-iterable prompt, mid-stream error propagation, send error). Full file: 15/15 passing.

## Out of scope (follow-ups)

- Capturing `AsyncIterable` (streamed) prompts as `input.value`.
- Hook-callback and in-process MCP tool span re-entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tracing for persistent `ClaudeSDKClient` sessions in `claude_agent_sdk`, matching the one-shot `query()` span shape. Each `query()`→`receive_response()` turn creates a `ClaudeAgent.query` root with nested LLM/tool/subagent spans (addresses #129).

- **New Features**
  - Wraps `query`/`receive_response`/`disconnect` via `wrap_client()` and wires into `instrument_claude_agent_sdk()`.
  - Reuses `_QueryState`; per-client turn state via `WeakKeyDictionary`.
  - Auto-closes unconsumed turns on new `query()` or `disconnect()`; real errors mark spans ERROR and propagate; instrumentation failures degrade to untraced.
  - Suppresses `asyncio.CancelledError` from normal cleanup; passthrough when `receive_response()` is called without a preceding `query()`.
  - Accepts async-iterable prompts; skips `input.value` for non-string inputs.
  - Guarded if `ClaudeSDKClient` is absent; no new dependencies.

<sup>Written for commit b2c8330bb7190cd14155fd43e73b01167c25c909. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

