### PR TITLE
feat(instrumentation): add Microsoft Agent Framework auto-instrumentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,10 @@ dependencies = [
 dspy = ["openinference-instrumentation-dspy>=0.1.34,<1.0", "dspy>=2.6.22,<4.0"]
 # Microsoft Agent Framework. Kept optional (like dspy) because its OpenInference
 # instrumentation requires opentelemetry>=1.39, above traceroot's >=1.34 floor.
-agent-framework = ["openinference-instrumentation-agent-framework>=0.1.0,<1.0"]
+agent-framework = [
+    "openinference-instrumentation-agent-framework>=0.1.0,<1.0",
+    "agent-framework-core>=1.0.0,<2.0",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "traceroot"
-version = "0.1.9"
+version = "0.1.10"
 description = "Python SDK for TraceRoot"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -43,6 +43,9 @@ dependencies = [
 
 [project.optional-dependencies]
 dspy = ["openinference-instrumentation-dspy>=0.1.34,<1.0", "dspy>=2.6.22,<4.0"]
+# Microsoft Agent Framework. Kept optional (like dspy) because its OpenInference
+# instrumentation requires opentelemetry>=1.39, above traceroot's >=1.34 floor.
+agent-framework = ["openinference-instrumentation-agent-framework>=0.1.0,<1.0"]
 
 [dependency-groups]
 dev = [

--- a/tests/test_auto_instrumentation.py
+++ b/tests/test_auto_instrumentation.py
@@ -7,7 +7,11 @@ from opentelemetry.sdk.trace import TracerProvider
 
 import traceroot
 from tests.utils import reset_traceroot
-from traceroot.instrumentation._instrumentors import AutogenInstrumentor, PydanticAIInstrumentor
+from traceroot.instrumentation._instrumentors import (
+    AgentFrameworkInstrumentor,
+    AutogenInstrumentor,
+    PydanticAIInstrumentor,
+)
 from traceroot.instrumentation.registry import (
     Integration,
     _is_package_installed,
@@ -504,9 +508,11 @@ def reset_custom_instrumentors():
     """Reset adapter instrumentor flags before and after each test."""
     AutogenInstrumentor._instrumented = False
     PydanticAIInstrumentor._instrumented = False
+    AgentFrameworkInstrumentor._instrumented = False
     yield
     AutogenInstrumentor._instrumented = False
     PydanticAIInstrumentor._instrumented = False
+    AgentFrameworkInstrumentor._instrumented = False
 
 
 def test_pydantic_ai_integration_enum_value():
@@ -677,3 +683,91 @@ def test_bedrock_missing_warns_and_skips(mock_installed, caplog):
     assert result == []
     assert "skipping" in caplog.text
     assert "boto3" in caplog.text
+
+
+# =============================================================================
+# Microsoft Agent Framework integration
+# =============================================================================
+
+
+def test_agent_framework_integration_enum_value():
+    assert Integration.AGENT_FRAMEWORK == "agent_framework"
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_agent_framework_skipped_if_not_installed(mock_installed, caplog):
+    import logging
+
+    mock_installed.return_value = False
+
+    provider = TracerProvider()
+    with caplog.at_level(logging.WARNING, logger="traceroot.instrumentation.registry"):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.AGENT_FRAMEWORK],
+        )
+
+    assert result == []
+    assert "skipping" in caplog.text
+    assert "agent-framework-core" in caplog.text
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_agent_framework_installs_processor_and_enables_instrumentation(mock_installed):
+    import sys
+
+    mock_installed.return_value = True
+
+    mock_processor = MagicMock()
+    mock_processor_cls = MagicMock(return_value=mock_processor)
+    mock_enable = MagicMock()
+
+    provider = MagicMock(spec=TracerProvider)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "openinference.instrumentation.agent_framework": MagicMock(
+                AgentFrameworkToOpenInferenceProcessor=mock_processor_cls
+            ),
+            "agent_framework.observability": MagicMock(enable_instrumentation=mock_enable),
+        },
+    ):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.AGENT_FRAMEWORK],
+        )
+
+    assert result == [Integration.AGENT_FRAMEWORK]
+    mock_processor_cls.assert_called_once_with()
+    provider.add_span_processor.assert_called_once_with(mock_processor)
+    mock_enable.assert_called_once_with(enable_sensitive_data=True)
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_agent_framework_idempotent(mock_installed):
+    """Calling initialize_integrations twice must not re-register the processor."""
+    import sys
+
+    mock_installed.return_value = True
+
+    mock_processor = MagicMock()
+    mock_processor_cls = MagicMock(return_value=mock_processor)
+    mock_enable = MagicMock()
+
+    provider = MagicMock(spec=TracerProvider)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "openinference.instrumentation.agent_framework": MagicMock(
+                AgentFrameworkToOpenInferenceProcessor=mock_processor_cls
+            ),
+            "agent_framework.observability": MagicMock(enable_instrumentation=mock_enable),
+        },
+    ):
+        initialize_integrations(provider, [Integration.AGENT_FRAMEWORK])
+        initialize_integrations(provider, [Integration.AGENT_FRAMEWORK])
+
+    assert provider.add_span_processor.call_count == 1
+    assert mock_enable.call_count == 1

--- a/traceroot/instrumentation/_instrumentors.py
+++ b/traceroot/instrumentation/_instrumentors.py
@@ -52,3 +52,36 @@ class PydanticAIInstrumentor:
 
     def uninstrument(self, **_kwargs: object) -> None:
         PydanticAIInstrumentor._instrumented = False
+
+
+class AgentFrameworkInstrumentor:
+    """Installs AgentFrameworkToOpenInferenceProcessor and enables Agent Framework telemetry.
+
+    Microsoft Agent Framework has built-in OpenTelemetry support but emits no spans
+    until enable_instrumentation() is called. Once enabled, it records native OTel
+    GenAI semconv spans on the global TracerProvider. AgentFrameworkToOpenInferenceProcessor
+    reshapes those spans in place into the OpenInference attribute schema that the
+    traceroot backend understands — so it must run before the export processor, which
+    holds because TracerootSpanProcessor batches (exports off-thread) while this
+    processor mutates synchronously in on_end.
+    """
+
+    _instrumented: bool = False
+
+    def instrument(self, tracer_provider: TracerProvider | None = None, **_kwargs: object) -> None:
+        if AgentFrameworkInstrumentor._instrumented:
+            return
+        from agent_framework.observability import enable_instrumentation
+        from openinference.instrumentation.agent_framework import (
+            AgentFrameworkToOpenInferenceProcessor,
+        )
+
+        if tracer_provider is not None:
+            tracer_provider.add_span_processor(AgentFrameworkToOpenInferenceProcessor())
+        # enable_sensitive_data=True captures prompt/response content, matching the
+        # behavior of traceroot's other content-capturing integrations.
+        enable_instrumentation(enable_sensitive_data=True)
+        AgentFrameworkInstrumentor._instrumented = True
+
+    def uninstrument(self, **_kwargs: object) -> None:
+        AgentFrameworkInstrumentor._instrumented = False

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -35,6 +35,7 @@ class Integration(StrEnum):
     MISTRAL = "mistral"
     PYDANTIC_AI = "pydantic_ai"
     BEDROCK = "bedrock"
+    AGENT_FRAMEWORK = "agent_framework"
 
 
 @dataclass
@@ -134,6 +135,11 @@ _BUILTIN_REGISTRY: dict[Integration, InstrumentorEntry] = {
         package="boto3",
         module_path="openinference.instrumentation.bedrock",
         class_name="BedrockInstrumentor",
+    ),
+    Integration.AGENT_FRAMEWORK: InstrumentorEntry(
+        package="agent-framework-core",
+        module_path="traceroot.instrumentation._instrumentors",
+        class_name="AgentFrameworkInstrumentor",
     ),
 }
 


### PR DESCRIPTION
## What

Adds auto-instrumentation support for the **Microsoft Agent Framework**.

Closes #132

## How

- **`Integration.AGENT_FRAMEWORK`** enum + registry entry (`registry.py`).
- **`AgentFrameworkInstrumentor`** (`_instrumentors.py`):
  - Calls `enable_instrumentation(enable_sensitive_data=True)` — the framework emits no spans until this is called; sensitive-data capture matches traceroot's other content-capturing integrations.
  - Registers `AgentFrameworkToOpenInferenceProcessor` on the `TracerProvider` to reshape native OTel GenAI spans into the OpenInference attribute schema in place. It mutates synchronously in `on_end`, so it runs before the batching export processor.
  - Idempotent via an `_instrumented` flag.
- **Optional dependency** `agent-framework` extra in `pyproject.toml` — kept optional (like `dspy`) because `openinference-instrumentation-agent-framework` requires `opentelemetry>=1.39`, above traceroot's `>=1.34` floor.
- Bumps version `0.1.9` → `0.1.10`.

## Tests

`tests/test_auto_instrumentation.py` adds coverage for:
- enum value
- graceful skip + warning when the package is not installed
- processor registration + `enable_instrumentation` call when present
- idempotency across repeated `initialize_integrations` calls

```
42 passed in 0.16s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds auto-instrumentation for Microsoft Agent Framework to emit GenAI spans and reshape them to the OpenInference schema for TraceRoot ingestion.

- **New Features**
  - New `Integration.AGENT_FRAMEWORK` to enable Agent Framework telemetry and register `AgentFrameworkToOpenInferenceProcessor` on the `TracerProvider`.
  - Idempotent and warns/skips if `agent-framework-core` is missing.
  - Tests cover enum value, skip behavior, processor registration, and idempotency.

- **Dependencies**
  - Optional extra `agent-framework` now installs `openinference-instrumentation-agent-framework>=0.1.0` and `agent-framework-core>=1.0.0` (kept optional due to `opentelemetry>=1.39`).
  - Fix: include `agent-framework-core` in the extra to prevent silent skip when installing `traceroot[agent-framework]`.
  - Bumps version to `0.1.10`.

<sup>Written for commit de23857a568e508d77dcd898620ceebef667f216. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

