### PR TITLE
fix(claude-agent-sdk): nest tool spans under their LLM turn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "traceroot"
-version = "0.1.10"
+version = "0.1.11"
 description = "Python SDK for TraceRoot"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_claude_agent_sdk.py
+++ b/tests/test_claude_agent_sdk.py
@@ -217,6 +217,46 @@ async def test_tool_spans_nest_under_their_llm_span():
 
 
 @pytest.mark.asyncio
+async def test_turns_split_on_tool_result_when_message_id_absent():
+    """message_id is an OPTIONAL SDK field. When it is missing, turns separated by a
+    tool_result must still become DISTINCT LLM spans (the tool_result is the boundary),
+    not collapse into one merged span with every tool nested under it."""
+    provider, exporter = _provider()
+    messages = [
+        # turn 1: no message_id, requests a tool
+        AssistantMessage(
+            [ToolUseBlock(id="c1", name="first_tool", input={"x": 1})],
+            model="claude-sonnet-4",
+        ),
+        UserMessage([ToolResultBlock(tool_use_id="c1", content="r1")]),
+        # turn 2: still no message_id, requests another tool
+        AssistantMessage(
+            [ToolUseBlock(id="c2", name="second_tool", input={"x": 2})],
+            model="claude-sonnet-4",
+        ),
+        UserMessage([ToolResultBlock(tool_use_id="c2", content="r2")]),
+        ResultMessage(
+            result="done", usage={"input_tokens": 5, "output_tokens": 20}, total_cost_usd=0.01
+        ),
+    ]
+    await _run(provider, messages)
+
+    spans = exporter.get_finished_spans()
+    llm = _llm_spans(exporter)
+    assert len(llm) == 2, f"expected 2 LLM turns split by the tool_result, got {len(llm)}"
+
+    # Each tool nests under its OWN turn, not both under one merged span.
+    first = next(s for s in spans if s.name == "first_tool")
+    second = next(s for s in spans if s.name == "second_tool")
+    assert first.parent is not None and second.parent is not None
+    assert first.parent.span_id != second.parent.span_id, (
+        "tools from different turns must not share one merged LLM span"
+    )
+    llm_ids = {s.context.span_id for s in llm}
+    assert first.parent.span_id in llm_ids and second.parent.span_id in llm_ids
+
+
+@pytest.mark.asyncio
 async def test_task_progress_only_creates_subagent_span():
     """A subagent that streams only TaskProgress (no TaskStarted) must still get a
     task span (named by role), parented under the Agent tool span."""

--- a/tests/test_claude_agent_sdk.py
+++ b/tests/test_claude_agent_sdk.py
@@ -186,6 +186,37 @@ async def test_tokens_on_llm_spans_not_on_query_or_task():
 
 
 @pytest.mark.asyncio
+async def test_tool_spans_nest_under_their_llm_span():
+    """A tool call must be a CHILD of the LLM span that requested it, not a flat
+    sibling under the query root: query -> LLM turn -> tool."""
+    provider, exporter = _provider()
+    messages = [
+        AssistantMessage(
+            [ToolUseBlock(id="c1", name="mcp__calc__multiply", input={"a": 17, "b": 23})],
+            model="claude-sonnet-4",
+            message_id="m1",
+            usage={"input_tokens": 5, "output_tokens": 2},
+        ),
+        UserMessage([ToolResultBlock(tool_use_id="c1", content="391")]),
+        ResultMessage(
+            result="391", usage={"input_tokens": 5, "output_tokens": 20}, total_cost_usd=0.01
+        ),
+    ]
+    await _run(provider, messages)
+
+    spans = exporter.get_finished_spans()
+    tool = next(s for s in spans if s.name == "mcp__calc__multiply")
+    llm = next(s for s in spans if s.name == "anthropic.messages.create")
+    query = next(s for s in spans if s.name == "ClaudeAgent.query")
+
+    assert tool.parent is not None
+    assert tool.parent.span_id == llm.context.span_id, (
+        "tool span must nest under its LLM span, not be a flat sibling under the query"
+    )
+    assert llm.parent is not None and llm.parent.span_id == query.context.span_id
+
+
+@pytest.mark.asyncio
 async def test_task_progress_only_creates_subagent_span():
     """A subagent that streams only TaskProgress (no TaskStarted) must still get a
     task span (named by role), parented under the Agent tool span."""

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -114,6 +114,14 @@ def _try_json(value: Any) -> str | None:
         return str(value)
 
 
+def _has_tool_result(message: Any) -> bool:
+    """True if a UserMessage carries any tool_result block (a turn boundary)."""
+    content = getattr(message, "content", None)
+    if not isinstance(content, list):
+        return False
+    return any(type(block).__name__ == "ToolResultBlock" for block in content)
+
+
 def _msg_type(message: Any) -> str:
     """Get message type from class name."""
     name = type(message).__name__
@@ -182,6 +190,10 @@ class _QueryState:
         self.open_llm_ctx: dict[str | None, otel_context.Context] = {}
         # Per-context id of the in-progress turn, to detect turn boundaries.
         self.current_message_ids: dict[str | None, str | None] = {}
+        # Contexts whose next AssistantMessage must begin a fresh turn because a
+        # tool_result just closed the prior one. This makes message_id (an
+        # optional SDK field) an optimization, not the sole boundary signal.
+        self.pending_turn_boundary: set[str | None] = set()
         # Accumulated assistant output blocks for the in-progress turn per context.
         self.llm_output_parts: dict[str | None, list[Any]] = {}
 
@@ -223,8 +235,13 @@ class _QueryState:
         key = getattr(message, "parent_tool_use_id", None)
         message_id = getattr(message, "message_id", None)
 
-        is_new_turn = key not in self.open_llm_spans or (
-            message_id is not None and self.current_message_ids.get(key) != message_id
+        forced = key in self.pending_turn_boundary
+        self.pending_turn_boundary.discard(key)
+
+        is_new_turn = (
+            key not in self.open_llm_spans
+            or forced
+            or (message_id is not None and self.current_message_ids.get(key) != message_id)
         )
 
         if is_new_turn:
@@ -423,6 +440,12 @@ class _QueryState:
 
         elif msg_type == "user":
             self._finish_tool_spans_from_message(message)
+            # A tool_result closes the current turn for its context: the next
+            # AssistantMessage there starts a fresh LLM turn even if message_id
+            # is absent. Key by the user message's parent_tool_use_id (the same
+            # context the answering AssistantMessage will carry).
+            if _has_tool_result(message):
+                self.pending_turn_boundary.add(getattr(message, "parent_tool_use_id", None))
 
         elif msg_type == "result":
             # Attach the ResultMessage usage to the orchestrator (None) span only;

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -173,14 +173,17 @@ class _QueryState:
         self.query_ctx = query_ctx
         self.prompt = prompt
 
-        # LLM span state
-        self.current_message_id: str | None = None
-        self.pending_messages: list[Any] = []
-        self.pending_start_time: float | None = None
-        # One open LLM span per agent context, keyed by the spawning tool's id
-        # (the root/top-level turn uses the None key); held open so the final
+        # LLM span state. One open LLM span per agent context, keyed by the
+        # spawning tool's id (the root/top-level turn uses the None key). Each
+        # turn's span is created eagerly on its first AssistantMessage and held
+        # open so (a) the tools it requests nest under it and (b) the final
         # ResultMessage usage can be recorded on the root turn's span.
         self.open_llm_spans: dict[str | None, trace.Span] = {}
+        self.open_llm_ctx: dict[str | None, otel_context.Context] = {}
+        # Per-context id of the in-progress turn, to detect turn boundaries.
+        self.current_message_ids: dict[str | None, str | None] = {}
+        # Accumulated assistant output blocks for the in-progress turn per context.
+        self.llm_output_parts: dict[str | None, list[Any]] = {}
 
         # Tool spans: tool_use_id → _ToolSpan
         self.active_tools: dict[str, _ToolSpan] = {}
@@ -212,62 +215,59 @@ class _QueryState:
 
     # -- LLM span management --
 
-    def flush_pending_llm(self) -> None:
-        if not self.pending_messages:
-            return
+    def _open_or_continue_llm_span(self, message: Any) -> tuple[trace.Span, otel_context.Context]:
+        """Return the LLM span for this message's turn, creating it eagerly on the
+        first AssistantMessage of the turn so the tools it requests can nest under
+        it. Consecutive messages sharing a message_id extend the same span.
+        """
+        key = getattr(message, "parent_tool_use_id", None)
+        message_id = getattr(message, "message_id", None)
 
-        first = self.pending_messages[0]
-        last = self.pending_messages[-1]
-
-        parent_tool_use_id = getattr(first, "parent_tool_use_id", None)
-        parent_ctx = self._get_task_parent_ctx(parent_tool_use_id)
-
-        start = self.pending_start_time or time.time()
-        start_ns = int(start * 1e9)
-
-        # Tile: close this context's previous open span at the new turn's start.
-        prev = self.open_llm_spans.pop(parent_tool_use_id, None)
-        if prev is not None:
-            prev.end(end_time=start_ns)
-
-        span = self.tracer.start_span(
-            LLM_SPAN_NAME,
-            attributes={OI_SPAN_KIND: "LLM"},
-            context=parent_ctx,
-            start_time=start_ns,
+        is_new_turn = key not in self.open_llm_spans or (
+            message_id is not None and self.current_message_ids.get(key) != message_id
         )
 
-        model = getattr(last, "model", None)
-        if not model:
-            for msg in reversed(self.pending_messages):
-                model = getattr(msg, "model", None)
-                if model:
-                    break
-        _set_model(span, model)
-        # No per-turn usage: streamed counts are unreliable. The ResultMessage total
-        # is attached to the orchestrator span in process_message().
+        if is_new_turn:
+            start_ns = int(time.time() * 1e9)
+            # Tile: close this context's previous open span at the new turn's start.
+            prev = self.open_llm_spans.pop(key, None)
+            if prev is not None:
+                prev.end(end_time=start_ns)
 
-        if not parent_tool_use_id and self.prompt:
-            val = _try_json([{"role": "user", "content": self.prompt}])
-            if val:
-                span.set_attribute(OI_INPUT_VALUE, val)
+            parent_ctx = self._get_task_parent_ctx(key)
+            span = self.tracer.start_span(
+                LLM_SPAN_NAME,
+                attributes={OI_SPAN_KIND: "LLM"},
+                context=parent_ctx,
+                start_time=start_ns,
+            )
+            span.set_status(StatusCode.OK)
+            # No per-turn usage: streamed counts are unreliable. The ResultMessage
+            # total is attached to the orchestrator span in process_message().
+            if key is None and self.prompt:
+                val = _try_json([{"role": "user", "content": self.prompt}])
+                if val:
+                    span.set_attribute(OI_INPUT_VALUE, val)
 
-        output_parts = []
-        for msg in self.pending_messages:
-            content = getattr(msg, "content", None)
-            if content is not None:
-                output_parts.append({"role": "assistant", "content": content})
-        if output_parts:
-            val = _try_json(output_parts)
+            self.open_llm_spans[key] = span
+            self.open_llm_ctx[key] = trace.set_span_in_context(span, parent_ctx)
+            self.current_message_ids[key] = message_id
+            self.llm_output_parts[key] = []
+
+        span = self.open_llm_spans[key]
+
+        model = getattr(message, "model", None)
+        if model:
+            _set_model(span, model)
+
+        content = getattr(message, "content", None)
+        if content is not None:
+            self.llm_output_parts[key].append({"role": "assistant", "content": content})
+            val = _try_json(self.llm_output_parts[key])
             if val:
                 span.set_attribute(OI_OUTPUT_VALUE, val)
 
-        span.set_status(StatusCode.OK)
-        # Keep open; closed on the next flush of this context or in end_all().
-        self.open_llm_spans[parent_tool_use_id] = span
-
-        self.pending_messages = []
-        self.pending_start_time = None
+        return span, self.open_llm_ctx[key]
 
     def _start_tool_spans_from_message(self, message: Any, llm_ctx: otel_context.Context) -> None:
         """Create tool spans from tool_use blocks in an AssistantMessage."""
@@ -415,25 +415,16 @@ class _QueryState:
         msg_type = _msg_type(message)
 
         if msg_type == "assistant":
-            message_id = getattr(message, "message_id", None)
-            if message_id and message_id != self.current_message_id:
-                self.flush_pending_llm()
-                self.current_message_id = message_id
-            if not self.pending_messages:
-                self.pending_start_time = time.time()
-            self.pending_messages.append(message)
-            # Create tool spans immediately (not waiting for flush) so that
-            # TaskStartedMessage can find the Agent tool span as parent.
-            parent_tool_use_id = getattr(message, "parent_tool_use_id", None)
-            tool_parent_ctx = self._get_task_parent_ctx(parent_tool_use_id)
-            self._start_tool_spans_from_message(message, tool_parent_ctx)
+            # Open (or extend) this turn's LLM span first, then nest the tools it
+            # requests under it: query -> LLM turn -> tool. The Agent tool span is
+            # created here so a later TaskStartedMessage can find it as parent.
+            _span, llm_ctx = self._open_or_continue_llm_span(message)
+            self._start_tool_spans_from_message(message, llm_ctx)
 
         elif msg_type == "user":
-            self.flush_pending_llm()
             self._finish_tool_spans_from_message(message)
 
         elif msg_type == "result":
-            self.flush_pending_llm()
             # Attach the ResultMessage usage to the orchestrator (None) span only;
             # subagent turns stay empty (sparse).
             result_usage = getattr(message, "usage", None)
@@ -459,7 +450,6 @@ class _QueryState:
     # -- Cleanup --
 
     def end_all(self, status: StatusCode = StatusCode.OK, error: str | None = None) -> None:
-        self.flush_pending_llm()
         for span in self.open_llm_spans.values():
             if error is not None:
                 span.set_status(status, error)

--- a/uv.lock
+++ b/uv.lock
@@ -2605,7 +2605,7 @@ wheels = [
 
 [[package]]
 name = "traceroot"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "openinference-instrumentation" },


### PR DESCRIPTION
## Problem

The in-house `claude-agent-sdk` instrumentation produced **flat traces**. Each turn's `anthropic.messages.create` LLM span was created lazily (on the *next* user/result message) and both LLM spans and tool spans were parented under the `ClaudeAgent.query` root. So a tool call appeared as a flat **sibling** of the LLM call that requested it, every trace was **depth 2**, and you couldn't tell which turn drove which tool — the agent's decision chain was invisible.

This affected all paths: `query()`, the persistent `ClaudeSDKClient`, MCP tools, and Skills.

## Fix

Create the LLM span **eagerly** on the first `AssistantMessage` of a turn (`_open_or_continue_llm_span`, create-or-merge keyed by `parent_tool_use_id`, tiling the prior turn shut), then parent that turn's tool spans under it. The span engine moves from "flush builds the span late" to "the span exists before its tools."

Result — `query -> LLM turn -> tool`:
- Tool / MCP / Skill / subagent `Agent` spans now nest under the LLM turn that invoked them.
- Subagent turns continue to parent under their task span.
- **Token/cost attribution is unchanged** (still attached from the `ResultMessage` to the orchestrator span).

## Before / after (same example, persistent client)

```
BEFORE (0.1.10)                    AFTER (0.1.11)
ClaudeAgent.query                  ClaudeAgent.query
├─ anthropic.messages.create       ├─ anthropic.messages.create
├─ Bash        ← flat sibling      │  └─ Bash       ← nested
└─ anthropic.messages.create       └─ anthropic.messages.create
```

Deep subagent workflow now reaches depth 6 (`query -> LLM turn -> Agent -> subagent -> LLM turn -> Bash`).

## Verification

- New regression test `test_tool_spans_nest_under_their_llm_span` (red before, green after); full suite **188 passed**; ruff clean.
- Verified end-to-end against live traces across every example path: one-shot `query()` + subagents, persistent `ClaudeSDKClient`, MCP tools, and Skills — all nest correctly, single root, token/cost identical to before.


## Screenshots

Before
<img width="1723" height="922" alt="Screenshot 2026-06-21 at 5 12 32 PM" src="https://github.com/user-attachments/assets/8bc225e3-bd9c-4030-aac6-bfc6f0f690e3" />

After

<img width="1721" height="919" alt="Screenshot 2026-06-21 at 5 12 19 PM" src="https://github.com/user-attachments/assets/e79632e3-ddc8-4a78-9484-7f00eebac0ab" />

## Note

Bumps version to **0.1.11** (the release this fix ships in). Happy to split the version bump into a separate chore PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes span hierarchy in `claude-agent-sdk` by eagerly opening each LLM turn and nesting tools under it, and by splitting turns on tool_result when `message_id` is missing. Traces now show query -> LLM turn -> tool while keeping token/cost attribution unchanged.

- **Bug Fixes**
  - Eagerly open/close LLM turn spans per `parent_tool_use_id`; nest tool/MCP/Skill/subagent Agent spans under the active turn; subagent LLM turns stay under their task spans.
  - Split turns on tool_result when `message_id` is absent to avoid merging id-less turns.
  - Add regression tests for tool nesting and for splitting id-less turns on tool_result.

- **Dependencies**
  - Bump `traceroot` to `0.1.11`.

<sup>Written for commit d3d2cc50bc53a17050b795a210c6e9e9a52f340a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

