### PR TITLE
ci: auto-announce releases to Discord with full notes

### DIFF
--- a/.github/workflows/announce-release-discord.yml
+++ b/.github/workflows/announce-release-discord.yml
@@ -1,0 +1,103 @@
+# .github/workflows/announce-release-discord.yml
+# Posts the FULL release notes (not just the title) to a Discord channel as a
+# rich embed. Replaces GitHub's native Discord integration, which only posts a
+# one-line title link for releases. The post's name + avatar come from the
+# Discord webhook's own config (set those in Discord, not here).
+#
+# Two triggers:
+#   - release: published   -> auto-announce every new release (uses the event payload)
+#   - workflow_dispatch     -> re-announce ANY existing tag on demand, for testing
+#                              the Discord path without cutting a real release
+#
+# Setup (one-time):
+#   1. Discord: #release channel -> Edit Channel -> Integrations -> Webhooks ->
+#      copy the webhook URL. Use the PLAIN URL (do NOT append /github).
+#   2. GitHub: repo Settings -> Secrets and variables -> Actions -> New secret
+#      named DISCORD_RELEASE_CHANNEL_WEBHOOK_URL = that plain URL.
+#   3. Remove the old native /github release webhook so releases don't double-post.
+name: Announce Release to Discord
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to (re)announce, e.g. v0.3.1"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: announce-release-${{ github.event.release.tag_name || github.event.inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post release notes to Discord
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_CHANNEL_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          # The tag from whichever trigger fired; passed via env (never inlined)
+          # so it can't break or inject into the script.
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          EV_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${WEBHOOK_URL:-}" ]; then
+            echo "::error::DISCORD_RELEASE_CHANNEL_WEBHOOK_URL secret is not set."
+            exit 1
+          fi
+
+          # Both triggers resolve to a tag, then fetch the release the same way,
+          # so a manual workflow_dispatch run exercises the exact path a real
+          # release:published takes.
+          TAG="${INPUT_TAG:-$EV_TAG}"
+          rel="$(gh release view "$TAG" --repo "$REPO" --json name,url,body)"
+          NAME="$(printf '%s' "$rel" | jq -r '.name')"
+          URL="$(printf '%s' "$rel" | jq -r '.url')"
+          BODY="$(printf '%s' "$rel" | jq -r '.body')"
+          [ -n "$NAME" ] && [ "$NAME" != "null" ] || NAME="$TAG"
+
+          # GitHub's auto-generated notes use H2 (##) section headers, which
+          # render oversized in Discord. Downgrade them to H3 (###) and promote
+          # the bold "Full Changelog" line to a matching H3, so every section
+          # header renders at one consistent, compact size.
+          BODY="$(printf '%s' "$BODY" | perl -pe 's/^## /### /; s/^\*\*Full Changelog\*\*:\s*(.*)$/### Full Changelog\n$1/')"
+
+          # Build the payload with jq so the body is JSON-escaped safely.
+          # Discord caps embed descriptions at 4096 chars; truncate by codepoint
+          # inside jq (never by byte, which can split a multi-byte char and emit
+          # invalid UTF-8) and append a "read more" link when the notes are long.
+          payload="$(jq -n \
+            --arg title "${REPO##*/} $NAME" \
+            --arg url "$URL" \
+            --arg desc "$BODY" \
+            --arg footer "$REPO" \
+            '{
+              embeds: [{
+                title: $title[0:256],
+                url: $url,
+                description: (
+                  if ($desc | length) > 3900
+                  then $desc[0:3900] + "\n\n… **[full release notes →](" + $url + ")**"
+                  else $desc
+                  end
+                ),
+                color: 5025616,
+                footer: { text: $footer }
+              }]
+            }')"
+
+          # Fail loudly on any non-2xx so a broken post is visible in CI.
+          curl -sS -f \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d "$payload" \
+            "$WEBHOOK_URL"
+          echo "Announced ${TAG} to Discord."


### PR DESCRIPTION
Adds the same release→Discord announcer that `traceroot-ai/traceroot` already runs.

On `release: published` (plus a manual `workflow_dispatch` re-announce), it fetches the
full release notes via `gh` and posts them as a rich embed to the shared `#release`
Discord channel. The embed title is prefixed with the repo name, so all repos land
cleanly in the one channel.

The `DISCORD_RELEASE_CHANNEL_WEBHOOK_URL` secret is already configured org-wide
(All repositories), so no per-repo setup is needed — this works on the next release.

Verbatim copy of the workflow in the main repo; no per-repo customization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that auto-announces releases to Discord with full release notes as a rich embed. Replaces the native integration’s one-line post and prefixes titles with the repo name for clarity in `#release`.

- **New Features**
  - Adds `.github/workflows/announce-release-discord.yml`; triggers on `release: published` and manual `workflow_dispatch` with a `tag`.
  - Fetches release data via `gh`, posts a rich embed, truncates safely and appends a “full release notes” link when long.
  - Normalizes headings (downgrades `##` to `###`, promotes “Full Changelog”) for cleaner Discord rendering.
  - Uses org secret `DISCORD_RELEASE_CHANNEL_WEBHOOK_URL`; no per-repo setup needed.
  - Concurrency keyed by tag to avoid duplicates; fails on non-2xx to surface errors.

<sup>Written for commit ede3ffaaa56f73b3b28dbef65cde56582ad38e59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

