### PR TITLE
fix: guard get_client() with double-checked locking to prevent duplicate client creation (Issue #118)

### DIFF
--- a/tests/test_get_client_race.py
+++ b/tests/test_get_client_race.py
@@ -1,0 +1,64 @@
+"""Test for get_client() concurrent initialization race condition fix."""
+
+import concurrent.futures
+import unittest.mock
+
+import pytest
+
+import traceroot
+
+
+@pytest.fixture(autouse=True)
+def reset_client():
+    """Reset global client before and after each test."""
+    traceroot._client = None
+    yield
+    traceroot._client = None
+    traceroot.shutdown()
+
+
+def test_get_client_concurrent_single_instance():
+    """Verify get_client() creates only one instance under concurrent load.
+
+    This test ensures that the double-checked locking pattern in get_client()
+    prevents the race condition where two concurrent calls both see _client=None
+    and both attempt to instantiate TracerootClient.
+
+    Regression test for issue #118.
+    """
+    # Mock the TracerootClient constructor to track instantiation count
+    call_count = 0
+    original_init = traceroot.TracerootClient.__init__
+
+    def counting_init(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        # Call original, but skip expensive initialization
+        with unittest.mock.patch.object(self, "_initialize", return_value=None):
+            original_init(self, *args, **kwargs)
+
+    with (
+        unittest.mock.patch.object(traceroot.TracerootClient, "__init__", counting_init),
+        concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor,
+    ):
+        # Launch multiple threads calling get_client() concurrently
+        futures = [executor.submit(traceroot.get_client) for _ in range(5)]
+        results = [f.result() for f in futures]
+
+    # All calls should return the same client instance
+    assert all(client is results[0] for client in results), (
+        "get_client() returned different instances across concurrent calls"
+    )
+
+    # Constructor should have been called exactly once, not five times
+    assert call_count == 1, (
+        f"TracerootClient.__init__ called {call_count} times, expected 1. "
+        "Race condition: multiple concurrent get_client() calls created multiple instances."
+    )
+
+
+def test_get_client_idempotent_single_thread():
+    """Verify get_client() returns the same instance when called repeatedly."""
+    client1 = traceroot.get_client()
+    client2 = traceroot.get_client()
+    assert client1 is client2, "get_client() returned different instances on sequential calls"

--- a/traceroot/__init__.py
+++ b/traceroot/__init__.py
@@ -114,10 +114,21 @@ def get_client() -> TracerootClient | None:
     If no client exists and TRACEROOT_API_KEY is set, automatically
     initializes a client with default settings from environment variables.
     This enables the @observe decorator to work without explicit initialize().
+
+    Thread-safe via double-checked locking: fast path (return existing client)
+    avoids lock acquisition; only first concurrent caller holds lock and creates.
     """
     global _client
-    if _client is None:
-        # Auto-initialize from env vars (TracerootClient reads them)
+    # Fast path: client already exists, no lock needed
+    if _client is not None:
+        return _client
+
+    # Slow path: lock and double-check before creating
+    with _init_lock:
+        # Another thread may have initialized while we waited for the lock
+        if _client is not None:
+            return _client
+        # Create and assign atomically within the lock
         _client = TracerootClient()
     return _client
 


### PR DESCRIPTION
Closes #118

get_client() had a check-then-act race: it read _client is None without holding _init_lock, so concurrent callers could both see None and both construct a TracerootClient. initialize() already uses _init_lock for the same reason, get_client() just didn't.

Fix: double-checked locking in get_client(), reusing the existing _init_lock — fast path returns early if already set, slow path re-checks inside the lock before creating.

Added tests/test_get_client_race.py: spawns 5 threads calling get_client() concurrently, asserts the constructor runs exactly once and all threads get the same instance, plus a sequential idempotency check.

Ran ruff check, ruff format --check, pytest tests/ locally — all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate client creation in concurrent get_client() calls. Fixes #118.

- **Bug Fixes**
  - Added double-checked locking with `_init_lock` so only one `TracerootClient` is created; fast path returns existing client, slow path re-checks after acquiring the lock.
  - Added tests to verify a single instantiation across 5 concurrent calls and idempotent sequential calls.

<sup>Written for commit 6af5d9a689e528d55d783ce0df60d31255a18929. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

