### PR TITLE
fix: reset global client on shutdown so reinit emits spans

### DIFF
--- a/tests/test_core_sdk.py
+++ b/tests/test_core_sdk.py
@@ -40,3 +40,30 @@ def test_shutdown():
     traceroot.shutdown()
 
     assert traceroot.get_client()._initialized is False
+
+
+def test_shutdown_resets_global_client_reference():
+    """Test shutdown() clears the module-level client so it can't be reused."""
+    reset_traceroot()
+
+    traceroot.initialize(api_key="test-key", enabled=False)
+    traceroot.shutdown()
+
+    assert traceroot._client is None
+
+
+def test_reinitialize_after_shutdown_creates_fresh_client():
+    """Test initialize() after shutdown() returns a new client, not the dead one.
+
+    Regression test for #117: shutdown() used to leave the dead client in
+    place, so a later initialize() hit the singleton guard and silently
+    returned the shutdown client instead of creating a fresh one.
+    """
+    reset_traceroot()
+
+    client1 = traceroot.initialize(api_key="key1", enabled=False)
+    traceroot.shutdown()
+    client2 = traceroot.initialize(api_key="key2", enabled=False)
+
+    assert client2 is not client1
+    assert traceroot.get_client() is client2

--- a/traceroot/__init__.py
+++ b/traceroot/__init__.py
@@ -129,9 +129,16 @@ def flush() -> None:
 
 
 def shutdown() -> None:
-    """Shutdown the SDK gracefully."""
-    if _client:
-        _client.shutdown()
+    """Shutdown the SDK gracefully.
+
+    Resets the global client to None so a later initialize()/get_client()
+    creates a fresh client instead of returning the dead, shutdown one.
+    """
+    global _client
+    with _init_lock:
+        if _client:
+            _client.shutdown()
+        _client = None
 
 
 __all__ = [


### PR DESCRIPTION
## Problem

Calling `traceroot.shutdown()` followed by `traceroot.initialize()` silently returns the dead, shutdown client instead of a fresh one — every span after reinit is silently dropped, with no error.

## Root cause

`shutdown()` (`traceroot/__init__.py`) called `_client.shutdown()` but never reset the module-level `_client` to `None`. `initialize()`'s singleton guard (`if _client is not None: return _client`) then returns the same dead object on the next call, and `get_client()` does the same.

## Change

`shutdown()` now resets `_client = None` under the existing `_init_lock`, so a later `initialize()`/`get_client()` creates a genuinely fresh client. Minimal, 2-line functional change (plus a docstring note).

## Validation

* [x] Added regression tests: `test_shutdown_resets_global_client_reference` and `test_reinitialize_after_shutdown_creates_fresh_client` (fail before the fix, pass after)
* [x] `uv run ruff check .` clean
* [x] Full suite: `uv run pytest tests/` — 191 passed
* [x] Coverage on changed lines: 100% (exercised by the two new tests)

## Risk / rollback

Low risk — `shutdown()` is the only touched function; no other call site relies on `_client` staying set after shutdown. Revert is a single-commit revert.

Closes #117


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the global tracer client on shutdown so re-initializing creates a fresh client and spans emit again. Fixes #117 where reinit returned a dead client and silently dropped spans.

- **Bug Fixes**
  - `shutdown()` now clears module-level `_client` (sets to `None`) under `_init_lock`.
  - Added regression tests to ensure the global reference is cleared and reinit returns a new client.

<sup>Written for commit 4d75bed1bedec36f239d580cf17d635c5a51424c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

