### PR TITLE
fix: activate generator span context so nested spans nest correctly

### DIFF
--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -467,3 +467,125 @@ def test_auto_initialization_without_explicit_initialize(memory_exporter):
     spans = memory_exporter.get_finished_spans()
     assert len(spans) == 1
     assert spans[0].name == "auto-init-test"
+
+
+def test_sync_generator_span_nesting(memory_exporter):
+    """Test nested spans inside a sync generator are children of the generator span.
+
+    This verifies that @observe-decorated sync generators correctly activate
+    their span context during execution, so nested @observe calls inside the
+    generator body correctly nest under the generator's span instead of
+    becoming orphaned or attaching to the wrong parent.
+    """
+
+    @observe(name="generator-child")
+    def generator_child():
+        return "child-result"
+
+    @observe(name="sync-generator")
+    def sync_gen():
+        yield "item-1"
+        # Call nested function inside generator body
+        result = generator_child()
+        yield f"item-2-{result}"
+
+    # Drain the generator fully
+    items = list(sync_gen())
+
+    assert len(items) == 2
+    assert items[0] == "item-1"
+    assert items[1] == "item-2-child-result"
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 2
+
+    spans_by_name = get_spans_by_name(memory_exporter)
+    generator_span = spans_by_name["sync-generator"]
+    child_span = spans_by_name["generator-child"]
+
+    # Verify parent-child relationship: child should have generator as parent
+    assert child_span.parent is not None
+    assert child_span.parent.span_id == generator_span.context.span_id
+
+
+@pytest.mark.asyncio
+async def test_async_generator_span_nesting(memory_exporter):
+    """Test nested spans inside an async generator are children of the generator span.
+
+    This verifies that @observe-decorated async generators correctly activate
+    their span context during execution, so nested @observe calls inside the
+    generator body correctly nest under the generator's span instead of
+    becoming orphaned or attaching to the wrong parent.
+    """
+
+    @observe(name="async-generator-child")
+    async def async_generator_child():
+        return "async-child-result"
+
+    @observe(name="async-generator")
+    async def async_gen():
+        yield "item-1"
+        # Call nested function inside generator body
+        result = await async_generator_child()
+        yield f"item-2-{result}"
+
+    # Drain the async generator fully
+    items = []
+    async for item in async_gen():
+        items.append(item)
+
+    assert len(items) == 2
+    assert items[0] == "item-1"
+    assert items[1] == "item-2-async-child-result"
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 2
+
+    spans_by_name = get_spans_by_name(memory_exporter)
+    generator_span = spans_by_name["async-generator"]
+    child_span = spans_by_name["async-generator-child"]
+
+    # Verify parent-child relationship: child should have generator as parent
+    assert child_span.parent is not None
+    assert child_span.parent.span_id == generator_span.context.span_id
+
+
+def test_sync_generator_no_context_leak_to_caller(memory_exporter):
+    """Test that generator context does not leak to caller after exhaustion.
+
+    This is a regression test for a naive fix that might leave the generator's
+    span context attached globally after the generator is exhausted. After the
+    generator completes, any new spans created from the caller's code should
+    not have the generator span as their parent.
+    """
+
+    @observe(name="sibling-after-gen")
+    def sibling_after_generator():
+        return "sibling-result"
+
+    @observe(name="context-leak-test-gen")
+    def context_leak_test_gen():
+        yield "item-1"
+        yield "item-2"
+
+    # Drain the generator
+    items = list(context_leak_test_gen())
+    assert len(items) == 2
+
+    # Now call a sibling function from the caller's code
+    # This should NOT have the generator as its parent
+    result = sibling_after_generator()
+    assert result == "sibling-result"
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 2
+
+    spans_by_name = get_spans_by_name(memory_exporter)
+    generator_span = spans_by_name["context-leak-test-gen"]
+    sibling_span = spans_by_name["sibling-after-gen"]
+
+    # Verify sibling does NOT have generator as parent
+    # (sibling should have no parent, since it's called at root level)
+    assert (
+        sibling_span.parent is None or sibling_span.parent.span_id != generator_span.context.span_id
+    )

--- a/traceroot/decorators.py
+++ b/traceroot/decorators.py
@@ -224,10 +224,10 @@ def _wrap_sync_generator(
     correctly nest under this generator's span, while the caller's code
     between yields does not inherit this context.
     """
-    span_ctx = trace.set_span_in_context(span)
     collected: list[Any] = []
     try:
         while True:
+            span_ctx = trace.set_span_in_context(span, context.get_current())
             token = context.attach(span_ctx)
             try:
                 item = next(gen)
@@ -263,11 +263,11 @@ async def _wrap_async_generator(
     correctly nest under this generator's span, while the caller's code
     between yields does not inherit this context.
     """
-    span_ctx = trace.set_span_in_context(span)
     agen = gen.__aiter__()
     collected: list[Any] = []
     try:
         while True:
+            span_ctx = trace.set_span_in_context(span, context.get_current())
             token = context.attach(span_ctx)
             try:
                 item = await agen.__anext__()

--- a/traceroot/decorators.py
+++ b/traceroot/decorators.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 from openinference.instrumentation import get_attributes_from_context
-from opentelemetry import trace
+from opentelemetry import context, trace
 from opentelemetry.trace import Status, StatusCode
 
 from traceroot.constants import SDK_VERSION, TRACEROOT_TRACER_NAME, SpanKind
@@ -215,10 +215,26 @@ def _wrap_sync_generator(
     span: trace.Span,
     capture_output: bool,
 ) -> Any:
-    """Yield items from a sync generator, keeping the span open until exhausted."""
+    """Yield items from a sync generator, keeping the span open until exhausted.
+
+    The span's context is attached only while the generator body is actively
+    executing (between resumptions), and detached again before control
+    returns to the caller at each yield. This ensures spans created inside
+    the generator body (nested @observe calls, auto-instrumented LLM calls)
+    correctly nest under this generator's span, while the caller's code
+    between yields does not inherit this context.
+    """
+    span_ctx = trace.set_span_in_context(span)
     collected: list[Any] = []
     try:
-        for item in gen:
+        while True:
+            token = context.attach(span_ctx)
+            try:
+                item = next(gen)
+            except StopIteration:
+                break
+            finally:
+                context.detach(token)
             collected.append(item)
             yield item
         if capture_output and collected:
@@ -238,10 +254,27 @@ async def _wrap_async_generator(
     span: trace.Span,
     capture_output: bool,
 ) -> Any:
-    """Yield items from an async generator, keeping the span open until exhausted."""
+    """Yield items from an async generator, keeping the span open until exhausted.
+
+    The span's context is attached only while the generator body is actively
+    executing (between resumptions), and detached again before control
+    returns to the caller at each yield. This ensures spans created inside
+    the generator body (nested @observe calls, auto-instrumented LLM calls)
+    correctly nest under this generator's span, while the caller's code
+    between yields does not inherit this context.
+    """
+    span_ctx = trace.set_span_in_context(span)
+    agen = gen.__aiter__()
     collected: list[Any] = []
     try:
-        async for item in gen:
+        while True:
+            token = context.attach(span_ctx)
+            try:
+                item = await agen.__anext__()
+            except StopAsyncIteration:
+                break
+            finally:
+                context.detach(token)
             collected.append(item)
             yield item
         if capture_output and collected:


### PR DESCRIPTION
## What

Fixes broken span nesting for `@observe`-decorated **generators** (sync and async) — the core distributed-trace hierarchy that TraceRoot's product is built on.

## Root cause

`sync_wrapper`/`async_wrapper` correctly use `tracer.start_as_current_span(...)`, which activates the span in OpenTelemetry's context so nested `@observe` calls and auto-instrumented LLM calls nest under it.

`_wrap_sync_generator`/`_wrap_async_generator` instead used `tracer.start_span(...)`, which creates the span but never activates it in context. So while a generator's body runs (a common pattern for streaming LLM output), any span created inside it — a nested `@observe` call, or an auto-instrumented OpenAI/Anthropic call — attaches to the wrong parent or becomes an orphaned root instead of nesting under the generator's own span.

Wrapping the whole generator in `with tracer.start_as_current_span(...):` isn't safe: a generator suspends its frame at every `yield` and hands control back to the caller, so an attached context would leak into the caller's code running between yields.

## Change

`_wrap_sync_generator` and `_wrap_async_generator` (`traceroot/decorators.py`) now attach the span's context only while the generator body is actively executing — around each `next()`/`anext()` call — and detach it again before yielding. This keeps nesting correct while the generator runs, without leaking context into the caller between yields. No changes to `observe()`'s public API or the non-generator wrappers.

## Validation

* [x] Added 3 regression tests in `tests/test_otel.py`: sync generator nesting, async generator nesting, and a context-leak guard (asserts the generator's context does *not* leak into caller code after exhaustion)
* [x] `uv run ruff check .` clean
* [x] `uv run ruff format --check .` clean on changed files
* [x] Full suite: `uv run pytest tests/` — 192 passed

## Risk / rollback

Low risk — change is scoped to two internal generator-wrapping helpers; span creation, output capture, and error-status behavior are all preserved exactly. Single-commit revert if needed.

Closes #119

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken span nesting for `@observe`-decorated sync/async generators by activating the generator span only while the generator body runs and restoring it on each resume. Nested spans now attach to the correct parent without leaking to the caller or overwriting other context updates between yields. Closes #119.

- **Bug Fixes**
  - In `_wrap_sync_generator` and `_wrap_async_generator`, attach the span context around each `next()`/`anext()` and detach before yielding; replaces `tracer.start_span(...)` without activation.
  - Rebuild the span context from `context.get_current()` on each resumption to preserve caller updates (e.g., baggage/session attrs) between yields.
  - Added regression tests for sync/async generator nesting and a context-leak guard.

<sup>Written for commit c105a2f402e95d604bab7d5ceeaf7e44d9167329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

