### PR TITLE
fix(sdk): warn when initialize() called with no integrations configured

### DIFF
--- a/tests/test_integration_smoothness.py
+++ b/tests/test_integration_smoothness.py
@@ -139,6 +139,26 @@ def test_missing_lib_continues_other_integrations(mock_installed):
     assert Integration.ANTHROPIC in result
 
 
+@pytest.mark.parametrize("integrations", [None, []])
+def test_warns_when_no_integrations_provided(integrations, caplog):
+    reset_traceroot()
+    from traceroot import client as client_mod
+
+    patcher = patch.object(client_mod.trace, "set_tracer_provider", autospec=True)
+    mock_set_tracer_provider = patcher.start()
+    mock_set_tracer_provider.return_value = None
+    try:
+        with caplog.at_level(logging.WARNING):
+            client = traceroot.initialize(api_key="test-key", integrations=integrations)
+    finally:
+        patcher.stop()
+
+    assert client.enabled is True
+    assert "no integrations provided" in caplog.text
+    assert "traceroot.initialize()" in caplog.text
+    assert "getting-started/quickstart" in caplog.text
+
+
 # =============================================================================
 # Issue 4: session_id / user_id on @observe
 # =============================================================================

--- a/traceroot/client.py
+++ b/traceroot/client.py
@@ -190,10 +190,10 @@ class TracerootClient:
             )
         else:
             logger.warning(
-                "TraceRoot: no integrations provided — LLM calls will not be traced. "
+                "TraceRoot: no integrations provided — LLM calls will not be auto-instrumented. "
                 "Pass integrations=[...] to traceroot.initialize(). See "
-                "https://traceroot.ai/docs/getting-started/quickstart"
-            )
+                "https://traceroot.ai/docs/tracing/get-started"
+        )
 
     @property
     def enabled(self) -> bool:

--- a/traceroot/client.py
+++ b/traceroot/client.py
@@ -181,12 +181,18 @@ class TracerootClient:
         logger.debug("Traceroot client initialized with TracerProvider")
 
         # Instrumentation (after TracerProvider is set up)
-        if self._integrations is not None:
+        if self._integrations:
             from traceroot.instrumentation.registry import initialize_integrations
 
             self._instrumented = initialize_integrations(
                 tracer_provider=self._provider,
                 integrations=self._integrations,
+            )
+        else:
+            logger.warning(
+                "TraceRoot: no integrations provided — LLM calls will not be traced. "
+                "Pass integrations=[...] to traceroot.initialize(). See "
+                "https://traceroot.ai/docs/getting-started/quickstart"
             )
 
     @property


### PR DESCRIPTION
## Summary
Emit a warning when `traceroot.initialize()` is called with no integrations configured (`None` or `[]`), so LLM calls going silently untraced is surfaced immediately rather than discovered later as missing spans.

Implements the scoped fix agreed on in traceroot-ai/traceroot#1226, following up on the silent partial-tracing failure originally surfaced in traceroot-ai/traceroot#1017.

## Type of Change
- [x] fix - A bug fix

## Details
- Changed the instrumentation gate in `TracerootClient` from a null check (`is not None`) to a truthiness check, so both `None` and `[]` correctly emit a warning and skip auto-instrumentation
- Warning follows existing `TraceRoot:` tone with a link to quickstart docs
- Added parametrized `caplog` test covering both `integrations=None` and `integrations=[]` cases in `test_integration_smoothness.py`

## Checklist
- [x] I have added/updated tests where applicable
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warn when `traceroot.initialize()` is called without integrations (`None` or `[]`) so missing LLM spans are surfaced early. Auto-instrumentation is skipped and a clear warning with an updated docs link is logged.

- **Bug Fixes**
  - Gate instrumentation with a truthy check on `self._integrations` so `None` and `[]` skip auto-instrumentation and warn.
  - Clarified warning text and pointed to https://traceroot.ai/docs/tracing/get-started; added a parametrized `caplog` test asserting the warning and that the client stays enabled.

<sup>Written for commit 675bbb6298c24272219c40370eba7e4c6f6f3f50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

