### PR TITLE
feat(eval): LLM-judge scorer — definition + rendering + self-instrumentation

### DIFF
--- a/traceroot/eval/scorers.py
+++ b/traceroot/eval/scorers.py
@@ -170,7 +170,11 @@ def describe_scorers(
         base_name = getattr(s, "__name__", None) or s.__class__.__name__
         # Honor the omitted-fields contract for direct consumers too: drop keys the scorer did not
         # declare (None) instead of exposing fabricated null schema fields.
-        desc = {k: v for k, v in scorer_metadata(s, value_type=hints.get(base_name)).items() if v is not None}
+        desc = {
+            k: v
+            for k, v in scorer_metadata(s, value_type=hints.get(base_name)).items()
+            if v is not None
+        }
         out.append(desc)
     return out
 
@@ -212,7 +216,9 @@ def _render_messages(messages: list[dict[str, str]], ctx: Any) -> list[dict[str,
 def _parse_judge_output(text: str, output_type: str) -> float | str:
     if output_type == "classification":
         return (text or "").strip()
-    match = re.search(r"-?\d+(?:\.\d+)?", text or "")
+    # Float-shaped: optional sign, leading-dot decimals (.8), and exponents (8e-1) — otherwise
+    # `.8` / `-.8` / `8e-1` mis-parse (e.g. `.8` matched as `8`).
+    match = re.search(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?", text or "")
     if not match:
         raise ValueError(f"llm_judge: no numeric score found in model output: {text[:200]!r}")
     return float(match.group())

--- a/traceroot/eval/scorers.py
+++ b/traceroot/eval/scorers.py
@@ -188,3 +188,147 @@ def _as_text(value: Any) -> str:
         return json.dumps(value, ensure_ascii=False)
     except TypeError:
         return str(value)
+
+
+def _render_messages(messages: list[dict[str, str]], ctx: Any) -> list[dict[str, str]]:
+    """Substitute {{input}}/{{output}}/{{expected}} into each message's content, per case.
+    The AUTHORED template (with placeholders) is what gets reported; this rendering is for
+    execution only."""
+    values = {
+        "input": _as_text(getattr(ctx, "input", None)),
+        "output": _as_text(getattr(ctx, "output", None)),
+        "expected": _as_text(getattr(ctx, "expected", None)),
+    }
+    rendered = []
+    for m in messages:
+        content = _PLACEHOLDER.sub(lambda mo: values[mo.group(1)], m.get("content", ""))
+        rendered.append({"role": m.get("role", "user"), "content": content})
+    return rendered
+
+
+def _parse_judge_output(text: str, output_type: str) -> float | str:
+    if output_type == "classification":
+        return (text or "").strip()
+    match = re.search(r"-?\d+(?:\.\d+)?", text or "")
+    if not match:
+        raise ValueError(f"llm_judge: no numeric score found in model output: {text[:200]!r}")
+    return float(match.group())
+
+
+def _provider_integration_traces(model: str) -> bool:
+    """True when an active traceroot integration already traces this model's provider calls.
+
+    In that case the judge must NOT add its own LLM span (the integration emits one for the
+    underlying request, and an LLM span nested inside an LLM span is redundant). The provider is
+    inferred from the model id the same way ``_default_complete`` dispatches: an anthropic model
+    checks the anthropic integration, otherwise openai.
+    """
+    try:
+        import traceroot
+        from traceroot.instrumentation import Integration
+
+        # Read the already-initialized client directly (do NOT call get_client(), which would
+        # auto-create one as a side effect). None -> not initialized -> no integration active.
+        active = set(getattr(getattr(traceroot, "_client", None), "_instrumented", None) or [])
+        if not active:
+            return False
+        m = (model or "").lower()
+        if m.startswith("claude") or m.startswith("anthropic"):
+            return Integration.ANTHROPIC in active
+        return Integration.OPENAI in active
+    except Exception:
+        return False
+
+
+def _default_complete(model: str, messages: list[dict[str, str]]) -> str:
+    """Best-effort provider dispatch used when no `complete` is injected. Lazily imports the
+    provider so the SDK never hard-depends on it; raises a clear error when unavailable."""
+    if model.startswith(("claude", "anthropic")):
+        try:
+            import anthropic
+        except ImportError as e:  # pragma: no cover - execution path, not unit-tested
+            raise RuntimeError(
+                "llm_judge needs the 'anthropic' package to call this model, or pass complete=..."
+            ) from e
+        system = "\n".join(m["content"] for m in messages if m["role"] == "system") or None
+        turns = [
+            {"role": m["role"], "content": m["content"]} for m in messages if m["role"] != "system"
+        ]
+        resp = anthropic.Anthropic().messages.create(
+            model=model, max_tokens=512, system=system, messages=turns
+        )
+        return "".join(getattr(b, "text", "") for b in resp.content)
+    try:
+        import openai
+    except ImportError as e:  # pragma: no cover
+        raise RuntimeError(
+            "llm_judge needs the 'openai' package to call this model, or pass complete=..."
+        ) from e
+    resp = openai.OpenAI().chat.completions.create(model=model, messages=messages)
+    return resp.choices[0].message.content or ""
+
+
+def llm_judge(
+    *,
+    name: str,
+    model: str,
+    messages: list[dict[str, str]],
+    version: str | None = None,
+    output_type: str = "score",
+    threshold: float | None = None,
+    description: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    direction: str | None = None,
+    value_type: str | None = None,
+    complete: Callable[[str, list[dict[str, str]]], str] | None = None,
+) -> Callable:
+    """A first-class LLM-judge scorer: its ``model`` + ``messages`` (the judge prompt) are
+    carried as the reported definition, and calling it runs the judge over a case.
+
+    ``messages`` are the AUTHORED template (``{{output}}``/``{{input}}``/``{{expected}}``
+    placeholders sent verbatim in the manifest); at run time they are rendered per case and
+    sent to the model. ``complete(model, messages) -> str`` overrides the model call (used in
+    tests / custom providers); the default lazily dispatches to anthropic/openai.
+    """
+    if output_type not in OUTPUT_TYPES:
+        raise ValueError(f"output_type must be one of {OUTPUT_TYPES}, got {output_type!r}")
+
+    from traceroot.constants import SpanKind
+    from traceroot.decorators import observe
+    from traceroot.eval.types import Score
+
+    def _call(rendered_messages: list[dict[str, str]]) -> str:
+        return (complete or _default_complete)(model, rendered_messages)
+
+    # Self-instrument the model call as an LLM span (nested under the scorer span) so the
+    # judge's LLM interaction shows in the trace without the caller wiring up provider
+    # auto-instrumentation: the rendered messages are the input, the model response the output.
+    @observe(name=f"llm_judge:{name}", type=SpanKind.LLM, metadata={"model": model})
+    def _call_instrumented(rendered_messages: list[dict[str, str]]) -> str:
+        return _call(rendered_messages)
+
+    def judge(ctx: Any) -> Any:
+        rendered = _render_messages(messages, ctx)
+        # If a provider integration is already tracing this model's calls, let IT own the LLM
+        # span (richer: tokens, native semantics) instead of adding our own — otherwise we'd
+        # nest an LLM span inside an LLM span. Self-instrument only when nothing else will.
+        invoke = _call if _provider_integration_traces(model) else _call_instrumented
+        text = invoke(rendered)
+        return Score(name, _parse_judge_output(text, output_type), comment=(text or "")[:2000])
+
+    judge.__name__ = name
+    meta = {
+        "name": name,
+        "version": version,
+        "scorer_type": "llm_judge",
+        "model": model,
+        "messages": messages,
+        "output_type": output_type,
+        "threshold": threshold,
+        "description": description,
+        "metadata": metadata,
+        "direction": direction,
+        "value_type": value_type,
+    }
+    setattr(judge, _META_ATTR, {k: v for k, v in meta.items() if v is not None})
+    return judge

--- a/traceroot/eval/scorers.py
+++ b/traceroot/eval/scorers.py
@@ -311,8 +311,11 @@ def llm_judge(
         rendered = _render_messages(messages, ctx)
         # If a provider integration is already tracing this model's calls, let IT own the LLM
         # span (richer: tokens, native semantics) instead of adding our own — otherwise we'd
-        # nest an LLM span inside an LLM span. Self-instrument only when nothing else will.
-        invoke = _call if _provider_integration_traces(model) else _call_instrumented
+        # nest an LLM span inside an LLM span. This only holds for the DEFAULT dispatch: a
+        # user-supplied `complete` is not provider-instrumented, so it must be self-instrumented
+        # (else its call would have no span at all), regardless of the model id.
+        provider_traced = complete is None and _provider_integration_traces(model)
+        invoke = _call if provider_traced else _call_instrumented
         text = invoke(rendered)
         return Score(name, _parse_judge_output(text, output_type), comment=(text or "")[:2000])
 

--- a/traceroot/eval/scorers.py
+++ b/traceroot/eval/scorers.py
@@ -295,6 +295,12 @@ def llm_judge(
     """
     if output_type not in OUTPUT_TYPES:
         raise ValueError(f"output_type must be one of {OUTPUT_TYPES}, got {output_type!r}")
+    # Validate the comparison metadata up front, like scorer() does, so an invalid direction or
+    # value_type can't reach the reported manifest.
+    if value_type is not None and value_type not in VALUE_TYPES:
+        raise ValueError(f"value_type must be one of {VALUE_TYPES}, got {value_type!r}")
+    if direction is not None and direction not in DIRECTIONS:
+        raise ValueError(f"direction must be one of {DIRECTIONS}, got {direction!r}")
 
     from traceroot.constants import SpanKind
     from traceroot.decorators import observe

--- a/traceroot/eval/types.py
+++ b/traceroot/eval/types.py
@@ -290,7 +290,13 @@ class Dataset:
             header = records[0]
             d = {
                 k: header.get(k)
-                for k in ("dataset_id", "name", "description", "base_version_id", "dataset_version_id")
+                for k in (
+                    "dataset_id",
+                    "name",
+                    "description",
+                    "base_version_id",
+                    "dataset_version_id",
+                )
             }
             d["cases"] = [{k: v for k, v in rec.items() if k != "type"} for rec in records[1:]]
             return cls.from_dict(d)


### PR DESCRIPTION
## Summary

Adds `llm_judge`, a first-class scorer whose model plus authored message template are its reported definition. On each case it renders the template with the case data, calls the model, and parses a score. It self-instruments the model call as a nested LLM span under the scorer span — but only when no provider integration is already tracing that model's calls, so a judge never nests an LLM span inside an LLM span.

Fixes: traceroot-ai/traceroot#1679

## How it works

The judge carries `model` and `messages` (the authored template, placeholders verbatim) as the definition reported in the run manifest. Only that template is reported — the per-case prompt rendered with real data is never sent. Per case, it fills `{{input}}` / `{{output}}` / `{{expected}}`, calls the model, and parses the result: a number for `output_type="score"`, or the raw label for `classification`.

```
llm_judge(model, messages)              → reported: model + authored template (placeholders verbatim)
  per case: render {{input/output/expected}}
    provider integration already tracing this model?
      yes → call model directly            (integration owns the richer LLM span)
      no  → call inside a nested LLM span   (rendered prompt = input, response = output)
```

`complete(model, messages) -> str` is injectable for tests and custom providers; the default lazily dispatches to the installed provider client, choosing the provider from the model id (Anthropic vs OpenAI) and raising a clear error when the package is absent. The integration check reads the already-initialized client's instrumented set directly (never auto-creating a client), and infers the provider the same way the default dispatch does.

## What's included

### Source
- `traceroot/eval/scorers.py` — `llm_judge(...)` and its helpers:
  - `_render_messages` — per-case placeholder substitution (execution only; the authored template is what's reported).
  - `_parse_judge_output` — numeric parse for `score`, raw label for `classification`.
  - `_provider_integration_traces` — whether an active integration already traces the model's provider, so the judge can skip its own span.
  - `_default_complete` — lazy Anthropic/OpenAI dispatch chosen from the model id, with a clear error when the provider package is missing.
  - the `judge` closure — self-instruments via `observe` as a nested LLM span only when nothing else will, and returns a `Score` with the model text as its comment; the reported meta carries `model` + `messages` and no source.

## Test plan

- [ ] The judge reports `model` + `messages` (authored template verbatim, placeholders not filled) and no source.
- [ ] Rendering fills `{{input}}` / `{{output}}` / `{{expected}}` per case, and the model call runs via the injected `complete`.
- [ ] A numeric score is parsed for `output_type="score"`, and the raw label is kept for `classification`.
- [ ] With no provider integration active, the judge emits its own nested LLM span under the scorer span.
- [ ] With an integration active for the model's provider, the judge does not emit its own LLM span (no double nesting).
- [ ] An invalid `output_type` is rejected, and a missing provider package raises a clear error.
