### PR TITLE
feat(eval): reporting transport + wire contract

### DIFF
--- a/tests/eval/test_main_score.py
+++ b/tests/eval/test_main_score.py
@@ -1,0 +1,61 @@
+"""Phase 2: boolean main-score behavior is consistent across local + cloud status.
+
+True -> 1.0, False -> 0.0 for the numeric MAIN score and passed/failed status; the
+individual scorer payload keeps the boolean as bool_value; errors stay distinct.
+"""
+
+from traceroot.eval import Score
+from traceroot.eval.platform import PlatformTransport
+from traceroot.eval.results import EvalItemResult, case_status
+
+
+def _item(scores, error=None):
+    return EvalItemResult("c", {}, {}, {}, scores, {}, error, None)
+
+
+def _t(main_name="m"):
+    return PlatformTransport(
+        "ds", scorer_names=["m"], main_score_name=main_name, api_key="tr-x", host_url="https://h"
+    )
+
+
+class TestCloudStatusAndMain:
+    def test_true_is_passed_1(self):
+        assert _t()._status_and_main(_item([Score("m", True)])) == ("passed", 1.0)
+
+    def test_false_is_failed_0(self):
+        assert _t()._status_and_main(_item([Score("m", False)])) == ("failed", 0.0)
+
+    def test_numeric_uses_threshold(self):
+        assert _t()._status_and_main(_item([Score("m", 0.5)])) == ("failed", 0.5)
+        assert _t()._status_and_main(_item([Score("m", 1.0)])) == ("passed", 1.0)
+
+    def test_categorical_main_is_not_scored(self):
+        assert _t()._status_and_main(_item([Score("m", "billing")])) == ("not_scored", None)
+
+    def test_missing_main_is_not_scored(self):
+        assert _t()._status_and_main(_item([])) == ("not_scored", None)
+
+    def test_task_error_is_errored(self):
+        assert _t()._status_and_main(_item([Score("m", True)], error="boom")) == ("errored", None)
+
+    def test_picks_named_main_over_others(self):
+        # only the main_score_name scorer drives status; a bool main is honored.
+        scores = [Score("other", 0.0), Score("m", True)]
+        assert _t("m")._status_and_main(_item(scores)) == ("passed", 1.0)
+
+
+class TestBooleanScorerPayloadStaysBool:
+    def test_bool_value_not_coerced_to_numeric(self):
+        payload = _t()._scores_payload(_item([Score("m", True)]))
+        assert payload[0]["bool_value"] is True
+        assert "numeric_value" not in payload[0]
+
+
+class TestLocalCloudConsistency:
+    def test_local_case_status_matches_cloud_for_bool(self):
+        # local case_status already maps bool -> 1/0; cloud must agree.
+        assert case_status(_item([Score("m", True)])) == "passed"
+        assert case_status(_item([Score("m", False)])) == "failed"
+        assert _t()._status_and_main(_item([Score("m", True)]))[0] == "passed"
+        assert _t()._status_and_main(_item([Score("m", False)]))[0] == "failed"

--- a/tests/eval/test_scorer_metadata.py
+++ b/tests/eval/test_scorer_metadata.py
@@ -1,0 +1,257 @@
+"""Phase 3: first-class scorer comparison metadata (name/version/value_type/direction/threshold).
+
+Authoring is via the @scorer decorator (or supported callable attributes); plain callables
+keep working. Defaults: numeric/boolean -> higher_is_better, categorical -> none; an explicit
+direction always wins; direction is NEVER inferred from the scorer name; version is never
+fabricated.
+"""
+
+import pytest
+
+from traceroot.eval import Score, ScorerContext, describe_scorers, llm_judge, scorer
+from traceroot.eval.scorers import scorer_metadata
+
+
+def test_plain_callable_has_name_no_version_no_type():
+    def routing_accuracy(ctx):
+        return 1.0
+
+    m = scorer_metadata(routing_accuracy)
+    assert m["name"] == "routing_accuracy"
+    assert m["version"] is None  # never fabricated
+    assert m["value_type"] is None  # unknown until it runs / declared
+    assert m["direction"] is None  # cannot default without a value_type
+
+
+def test_numeric_defaults_higher_is_better():
+    @scorer(value_type="numeric")
+    def acc(ctx):
+        return 1.0
+
+    m = scorer_metadata(acc)
+    assert (m["value_type"], m["direction"]) == ("numeric", "higher_is_better")
+
+
+def test_boolean_defaults_higher_is_better():
+    @scorer(value_type="boolean")
+    def safe(ctx):
+        return True
+
+    assert scorer_metadata(safe)["direction"] == "higher_is_better"
+
+
+def test_categorical_defaults_none():
+    @scorer(value_type="categorical")
+    def route(ctx):
+        return "billing"
+
+    assert scorer_metadata(route)["direction"] == "none"
+
+
+def test_explicit_direction_wins():
+    @scorer(value_type="numeric", direction="lower_is_better", threshold=100)
+    def latency(ctx):
+        return 42.0
+
+    m = scorer_metadata(latency)
+    assert m["direction"] == "lower_is_better"
+    assert m["threshold"] == 100
+
+
+def test_direction_not_inferred_from_name():
+    # a scorer literally named "latency" must NOT be guessed as lower_is_better.
+    @scorer(value_type="numeric")
+    def latency(ctx):
+        return 42.0
+
+    assert scorer_metadata(latency)["direction"] == "higher_is_better"
+
+
+def test_declared_name_and_version_win():
+    @scorer(name="Routing accuracy", version="v3")
+    def acc(ctx):
+        return 1.0
+
+    m = scorer_metadata(acc)
+    assert m["name"] == "Routing accuracy" and m["version"] == "v3"
+
+
+def test_invalid_value_type_or_direction_raise():
+    with pytest.raises(ValueError):
+        scorer(value_type="nonsense")
+    with pytest.raises(ValueError):
+        scorer(direction="up")
+
+
+def test_describe_scorers_list_and_value_type_hint():
+    @scorer(direction="lower_is_better")
+    def latency(ctx):
+        return 1.0
+
+    def acc(ctx):
+        return Score("acc", 1.0)
+
+    specs = describe_scorers([acc, latency], value_types={"latency": "numeric"})
+    by = {s["name"]: s for s in specs}
+    # a runtime value_type hint fills an undeclared value_type
+    assert by["latency"]["value_type"] == "numeric"
+    assert by["latency"]["direction"] == "lower_is_better"
+    assert by["acc"]["value_type"] is None  # no hint, not declared
+
+
+class TestScorerSpecsOnWire:
+    def test_create_run_emits_rich_scorer_descriptors(self):
+        from traceroot.eval.platform import PlatformTransport
+
+        @scorer(value_type="numeric", direction="higher_is_better", threshold=0.9, version="v2")
+        def acc(ctx):
+            return 1.0
+
+        t = _recording(PlatformTransport)
+        t.scorer_specs = describe_scorers([acc])
+        t.main_score_name = "acc"
+        t.create_run("r", "d", None)
+        (sc,) = t.reqs[0][2]["scorers"]
+        # comparison metadata
+        assert sc["name"] == "acc" and sc["version"] == "v2"
+        assert sc["value_type"] == "numeric" and sc["direction"] == "higher_is_better"
+        assert sc["threshold"] == 0.9
+        # definition fields ride the same descriptor
+        assert sc["scorer_type"] == "code" and sc["output_type"] == "score"
+        assert sc["language"] == "python" and "def acc" in sc["source"]
+
+    def test_declared_threshold_drives_cloud_status(self):
+        from traceroot.eval.platform import PlatformTransport
+        from traceroot.eval.results import EvalItemResult
+
+        @scorer(value_type="numeric", threshold=0.8)
+        def acc(ctx):
+            return 0.85
+
+        t = PlatformTransport("ds", main_score_name="acc", api_key="tr-x", host_url="https://h")
+        t.scorer_specs = describe_scorers([acc])
+        # 0.85 >= declared threshold 0.8 -> passed (would be "failed" against the 1.0 default)
+        item = EvalItemResult("c", {}, {}, {}, [Score("acc", 0.85)], {}, None, None)
+        assert t._status_and_main(item) == ("passed", 0.85)
+
+    def test_plain_names_still_work_without_specs(self):
+        from traceroot.eval.platform import PlatformTransport
+
+        t = _recording(PlatformTransport)
+        t.create_run("r", "d", None)
+        assert t.reqs[0][2]["scorers"] == [{"name": "acc", "version": "unversioned"}]
+
+
+def _recording(cls):
+    t = cls("ds_1", scorer_names=["acc"], api_key="tr-x", host_url="https://h")
+    t.reqs = []
+    t._request = lambda m, p, b=None: t.reqs.append((m, p, b)) or {"evaluation_run_id": "run_1"}
+    return t
+
+
+# --- scorer definition (read-only Scorer detail) ------------------------------------
+
+
+def test_code_scorer_reports_type_source_and_output_type():
+    @scorer(output_type="score", threshold=1.0, description="Exact match", metadata={"team": "q"})
+    def exact_match(ctx):
+        return 1.0 if ctx.output == ctx.expected else 0.0
+
+    m = scorer_metadata(exact_match)
+    assert m["scorer_type"] == "code"
+    assert m["language"] == "python"
+    assert "def exact_match(ctx):" in m["source"]
+    assert "@scorer" not in m["source"]  # decorator line stripped
+    assert m["output_type"] == "score"
+    assert m["threshold"] == 1.0
+    assert m["description"] == "Exact match"
+    assert m["metadata"] == {"team": "q"}
+
+
+def test_multiline_decorator_is_fully_stripped_from_source():
+    # A multi-line @scorer(...) must not leak its argument lines into the captured source;
+    # the definition should begin at the function's own `def` header.
+    @scorer(
+        value_type="numeric",
+        direction="higher_is_better",
+        threshold=1.0,
+        description="both cities present",
+        metadata={"kind": "coverage"},
+    )
+    def covers_both_cities(ctx):
+        text = (ctx.output or "").lower()
+        return 1.0 if "sf" in text and "tokyo" in text else 0.0
+
+    src = scorer_metadata(covers_both_cities)["source"]
+    assert src.startswith("def covers_both_cities(ctx):")  # begins at def, no decorator args
+    assert "@scorer" not in src
+    assert "value_type=" not in src and "metadata=" not in src  # no leaked decorator arg lines
+
+
+def test_output_type_derived_from_value_type_but_explicit_wins():
+    @scorer(value_type="categorical")
+    def route(ctx):
+        return "billing"
+
+    assert scorer_metadata(route)["output_type"] == "classification"
+
+    @scorer(value_type="categorical", output_type="score")
+    def weird(ctx):
+        return "x"
+
+    assert scorer_metadata(weird)["output_type"] == "score"  # explicit wins
+
+
+def test_undeclared_definition_fields_are_none_then_omitted():
+    def plain(ctx):
+        return 1.0
+
+    m = scorer_metadata(plain)
+    assert m["scorer_type"] == "code"  # always present
+    assert m["output_type"] is None  # no value_type -> not derived
+    assert m["description"] is None and m["metadata"] is None
+    # code scorers still report their source (it is the real definition, not inference)
+    assert "def plain" in m["source"]
+
+
+def test_llm_judge_reports_model_and_messages_not_source():
+    concise = llm_judge(
+        name="concise",
+        version="1",
+        model="claude-sonnet-5",
+        messages=[
+            {"role": "system", "content": "Rate 0..1."},
+            {"role": "user", "content": "ANSWER:\n{{output}}"},
+        ],
+        output_type="score",
+        threshold=0.8,
+        description="conciseness",
+        metadata={"team": "quality"},
+    )
+    m = scorer_metadata(concise)
+    assert m["scorer_type"] == "llm_judge"
+    assert m["model"] == "claude-sonnet-5"
+    assert m["messages"][1]["content"] == "ANSWER:\n{{output}}"  # authored template, verbatim
+    assert m["output_type"] == "score" and m["threshold"] == 0.8
+    assert "source" not in m and "language" not in m
+
+
+def test_llm_judge_executes_with_injected_complete_and_renders_placeholders():
+    seen = {}
+
+    def fake_complete(model, messages):
+        seen["model"] = model
+        seen["rendered"] = messages
+        return "The score is 0.7 out of 1."
+
+    concise = llm_judge(
+        name="concise",
+        model="claude-sonnet-5",
+        messages=[{"role": "user", "content": "ANSWER:\n{{output}}"}],
+        complete=fake_complete,
+    )
+    ctx = ScorerContext(input="q", output="a concise answer", expected=None, metadata=None)
+    score = concise(ctx)
+    assert score.name == "concise" and score.value == 0.7  # parsed numeric
+    assert seen["model"] == "claude-sonnet-5"
+    assert seen["rendered"][0]["content"] == "ANSWER:\na concise answer"  # {{output}} rendered

--- a/tests/eval/test_scorer_metadata.py
+++ b/tests/eval/test_scorer_metadata.py
@@ -96,7 +96,7 @@ def test_describe_scorers_list_and_value_type_hint():
     # a runtime value_type hint fills an undeclared value_type
     assert by["latency"]["value_type"] == "numeric"
     assert by["latency"]["direction"] == "lower_is_better"
-    assert by["acc"]["value_type"] is None  # no hint, not declared
+    assert "value_type" not in by["acc"]  # undeclared fields are omitted, not exposed as null
 
 
 class TestScorerSpecsOnWire:

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -168,14 +168,15 @@ class PlatformTransport:
         # Already sent inside record_item_result (which carries the full item).
         return None
 
-    def finish_run(self, run: RunHandle) -> UploadState:
+    def finish_run(self, run: RunHandle, status: str | None = None) -> UploadState:
+        effective = status or (
+            "completed_with_errors" if (self._task_errors or self._scorer_errors) else "completed"
+        )
         self._request(
             "POST",
             f"/api/public/evaluation-runs/{self.run_id}/complete",
             {
-                "status": "completed_with_errors"
-                if (self._task_errors or self._scorer_errors)
-                else "completed",
+                "status": effective,
                 "scored_count": self._scored,
                 "task_error_count": self._task_errors,
                 "scorer_error_count": self._scorer_errors,

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -158,6 +158,7 @@ class PlatformTransport:
             )
         self.host_url = self.host_url.rstrip("/")
         self.run_id: str | None = None
+        self.run_path: str | None = None  # UI-relative run path, when the backend returns one
         self._scored = 0
         self._task_errors = 0
         self._scorer_errors = 0
@@ -195,6 +196,8 @@ class PlatformTransport:
             body["client_run_id"] = effective_crun
         resp = self._request("POST", "/api/v1/public/evaluation-runs", body)
         self.run_id = resp["evaluation_run_id"]
+        # Optional: absent on older/self-hosted backends -> dashboard_url stays None.
+        self.run_path = resp.get("run_path")
         return RunHandle(name=name, dataset_name=dataset_name, metadata=metadata)
 
     def _scorer_refs(self) -> list[dict[str, Any]]:
@@ -286,8 +289,10 @@ class PlatformTransport:
             f"/api/v1/public/evaluation-runs/{self.run_id}/complete",
             body,
         )
-        # The backend returns no dashboard URL; report uploaded with url unknown.
-        return UploadState(status="uploaded", dashboard_url=None)
+        # Join the backend's UI-relative run path with our host to form a clickable
+        # link; None when the backend did not return one (older/self-hosted).
+        url = f"{self.host_url}{self.run_path}" if self.run_path else None
+        return UploadState(status="uploaded", dashboard_url=url)
 
     def publish_dataset(self, dataset_name: str, item_count: int) -> PublishResult:
         # Datasets are server/UI-owned; the SDK cannot create them. Stay local-only.

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -42,14 +42,38 @@ def _as_text(value: Any) -> str | None:
     return json.dumps(serialize_value(value))
 
 
-def _decode_field(value: Any) -> Any:
-    """Inverse of the backend's JSON-text storage for a dataset case's input/expected.
+# --- canonical codec for a dataset case's ``input`` / ``expected`` -----------
+# The backend stores these in a TEXT column with no type marker and never parses
+# them on read (see offline-eval/contract-notes/dataset-json-roundtrip.md). Its
+# ``toText`` stores an SDK-sent STRING verbatim and JSON-stringifies anything else.
+# So the ONLY way to preserve the original value's type across a round trip is for
+# the SDK to own a canonical encoding on BOTH ends: always send JSON text on push
+# (``_encode_field``) and always JSON-decode on pull (``_decode_field``). This makes
+# a genuine string survive as a string even when it contains JSON-looking text
+# (it is stored as ``"{...}"`` with quotes), which a bare ``json.loads`` of the raw
+# column could not guarantee.
 
-    The backend persists these as JSON text and returns them as strings, so a
-    pushed dict must be decoded back to a dict (otherwise a task doing
-    ``input["message"]`` subscripts a str). ``json.loads`` is the exact inverse of
-    the stored ``json.dumps``; a value that is already native, or a plain string
-    the backend did not JSON-encode, is returned unchanged.
+
+def _encode_field(value: Any) -> str:
+    """Canonical push encoding for a case's ``input``/``expected``: JSON text.
+
+    Emitting JSON text (a string) means the backend's TEXT column stores it
+    verbatim, so ``_decode_field`` is an exact inverse for every JSON type -- dict,
+    list, number, bool, null, and genuine strings (including JSON-looking ones).
+    A dict still serializes to the same bytes the backend produced before, so
+    already-published dict data keeps round-tripping.
+    """
+    return json.dumps(serialize_value(value))
+
+
+def _decode_field(value: Any) -> Any:
+    """Pull decoding: the exact inverse of :func:`_encode_field`.
+
+    ``metadata`` (a native JSONB column) arrives already parsed and is passed
+    through untouched. For ``input``/``expected`` the backend returns the stored
+    text; ``json.loads`` reconstructs the original value. A value that is already
+    native, or legacy text a foreign writer stored without canonical encoding
+    (e.g. a bare non-JSON string), is returned unchanged.
     """
     if not isinstance(value, str):
         return value

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -126,7 +126,6 @@ class PlatformTransport:
         environment: str = "evaluation",
         main_score_name: str | None = None,
         dataset_version_id: str | None = None,
-        baseline_run_id: str | None = None,
         client_run_id: str | None = None,
         pass_threshold: float | None = None,
         scorer_specs: list[dict[str, Any]] | None = None,
@@ -145,9 +144,6 @@ class PlatformTransport:
             self.scorer_names[0] if self.scorer_names else None
         )
         self.dataset_version_id = dataset_version_id
-        # Links this run to a baseline run so the platform/UI can show the comparison
-        # (Change / regressions). Without it a reported run shows "No baseline".
-        self.baseline_run_id = baseline_run_id
         self.client_run_id = client_run_id
         self.pass_threshold = pass_threshold
         self.api_key, self.host_url = _resolve_credentials(api_key, host_url)
@@ -188,8 +184,6 @@ class PlatformTransport:
             body["dataset_version_id"] = self.dataset_version_id
         if self.main_score_name is not None:
             body["main_score_name"] = self.main_score_name
-        if self.baseline_run_id is not None:
-            body["baseline_run_id"] = self.baseline_run_id
         # Idempotency key: prefer the one the RunSession drives with, else our own.
         effective_crun = client_run_id or self.client_run_id
         if effective_crun is not None:

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -241,6 +241,14 @@ class PlatformTransport:
                 return float(spec["threshold"])
         return _DEFAULT_PASS_THRESHOLD
 
+    def _effective_direction(self) -> str:
+        """The main scorer's DECLARED comparison direction (higher_is_better by default).
+        lower_is_better inverts the threshold comparison; none -> not_scored."""
+        for spec in self.scorer_specs or []:
+            if spec.get("name") == self.main_score_name and spec.get("direction") is not None:
+                return str(spec["direction"])
+        return "higher_is_better"
+
     def register_item(self, run: RunHandle, case: EvalCase) -> None:
         # The item->trace link is folded into the result upsert (contract), so no-op.
         return None
@@ -355,7 +363,15 @@ class PlatformTransport:
                 break
         if main is None:
             return "not_scored", None
-        return ("passed" if main >= self._effective_threshold() else "failed"), main
+        threshold = self._effective_threshold()
+        direction = self._effective_direction()
+        if direction == "lower_is_better":
+            passed = main <= threshold
+        elif direction == "none":
+            return "not_scored", main
+        else:  # higher_is_better (the default)
+            passed = main >= threshold
+        return ("passed" if passed else "failed"), main
 
 
 def _dataset_from_version(snapshot: dict, name: str) -> Dataset:

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -128,12 +128,17 @@ class PlatformTransport:
         dataset_version_id: str | None = None,
         baseline_run_id: str | None = None,
         client_run_id: str | None = None,
-        pass_threshold: float = _DEFAULT_PASS_THRESHOLD,
+        pass_threshold: float | None = None,
+        scorer_specs: list[dict[str, Any]] | None = None,
         api_key: str | None = None,
         host_url: str | None = None,
     ) -> None:
         self.dataset_id = dataset_id
         self.scorer_names = scorer_names or []
+        # Rich scorer descriptors (name/version/value_type/direction/threshold). The engine
+        # fills this from the actual scorer callables when the caller leaves it None; an
+        # explicit value wins. Falls back to scorer_names when unset.
+        self.scorer_specs = scorer_specs
         self.candidate_version = candidate_version or "sdk"
         self.environment = environment
         self.main_score_name = main_score_name or (
@@ -176,9 +181,7 @@ class PlatformTransport:
             "dataset_id": self.dataset_id,
             "candidate_version": self.candidate_version,
             "environment": self.environment,
-            # The transport only knows scorer names, not declared versions. The backend
-            # requires a non-empty version string, so unversioned scorers use the sentinel.
-            "scorers": [{"name": n, "version": _UNVERSIONED_SCORER} for n in self.scorer_names],
+            "scorers": self._scorer_refs(),
         }
         if self.dataset_version_id is not None:
             body["dataset_version_id"] = self.dataset_version_id
@@ -193,6 +196,36 @@ class PlatformTransport:
         resp = self._request("POST", "/api/v1/public/evaluation-runs", body)
         self.run_id = resp["evaluation_run_id"]
         return RunHandle(name=name, dataset_name=dataset_name, metadata=metadata)
+
+    def _scorer_refs(self) -> list[dict[str, Any]]:
+        """Scorer descriptors for run registration. Prefers rich specs (value_type/
+        direction/threshold, forward-compatible) and falls back to name/version. The
+        backend requires a non-empty version string, so unversioned scorers use the
+        sentinel; optional metadata fields are omitted when unknown."""
+        if self.scorer_specs:
+            refs = []
+            for spec in self.scorer_specs:
+                ref: dict[str, Any] = {
+                    "name": spec["name"],
+                    "version": spec.get("version") or _UNVERSIONED_SCORER,
+                }
+                for k in ("value_type", "direction", "threshold"):
+                    if spec.get(k) is not None:
+                        ref[k] = spec[k]
+                refs.append(ref)
+            return refs
+        return [{"name": n, "version": _UNVERSIONED_SCORER} for n in self.scorer_names]
+
+    def _effective_threshold(self) -> float:
+        """The pass threshold for status: an explicit pass_threshold wins; else the main
+        scorer's DECLARED threshold; else the default. Keeps cloud status in agreement
+        with a scorer's declared threshold (Phase 3)."""
+        if self.pass_threshold is not None:
+            return self.pass_threshold
+        for spec in self.scorer_specs or []:
+            if spec.get("name") == self.main_score_name and spec.get("threshold") is not None:
+                return float(spec["threshold"])
+        return _DEFAULT_PASS_THRESHOLD
 
     def register_item(self, run: RunHandle, case: EvalCase) -> None:
         # The item->trace link is folded into the result upsert (contract), so no-op.
@@ -304,7 +337,7 @@ class PlatformTransport:
                 break
         if main is None:
             return "not_scored", None
-        return ("passed" if main >= self.pass_threshold else "failed"), main
+        return ("passed" if main >= self._effective_threshold() else "failed"), main
 
 
 def _dataset_from_version(snapshot: dict, name: str) -> Dataset:

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -371,6 +371,9 @@ def pull_dataset(
 ) -> Dataset:
     """Fetch a platform dataset into a local :class:`Dataset`.
 
+    Pull data, not runs: reproduce a run by pulling its ``dataset_version_id`` (see
+    :func:`pull_dataset_version`) -- there is no ``pull_run``.
+
     Without ``version_id`` the dataset's CURRENT version is pulled. With ``version_id``
     that EXACT immutable version is pulled and validated to belong to ``dataset_id`` --
     the current version is never silently substituted, so a run can reproduce the precise
@@ -401,6 +404,11 @@ def pull_dataset_version(
     host_url: str | None = None,
 ) -> Dataset:
     """Fetch one EXACT immutable dataset version by its id.
+
+    Pull data, not runs: this is how you reproduce a run -- pass the run's
+    ``dataset_version_id`` to get the exact cases it scored, then supply your own task +
+    scorers. There is no ``pull_run`` (a run is task + scorers + data; only the data is
+    on the platform).
 
     When ``dataset_id`` is supplied, the returned version is validated to belong to it
     (a mismatch raises ``ValueError`` rather than silently returning the wrong data).

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -19,6 +19,7 @@ dataset_version_id, so datasets are FETCHED (``pull_dataset``), not created here
 from __future__ import annotations
 
 import json
+import os
 import urllib.error
 import urllib.request
 from typing import Any
@@ -43,7 +44,14 @@ def _as_text(value: Any) -> str | None:
 
 
 def _resolve_credentials(api_key: str | None, host_url: str | None) -> tuple[str, str]:
-    """Fill api_key/host_url from the global client when not explicitly given."""
+    """Resolve (api_key, eval_api_base) for the ``/api/public/*`` endpoints.
+
+    api_key/host_url fall back to the global client. The eval endpoints
+    (``/api/public/*``) live in the TraceRoot app; in production that is the same
+    origin as tracing, but in local dev the app (Next.js) and the trace-ingest
+    backend (Python) run on different ports. ``TRACEROOT_EVAL_API_URL`` overrides the
+    base for eval calls only (traces are unaffected); unset -> use host_url.
+    """
     if api_key is None or host_url is None:
         from traceroot import get_client
 
@@ -51,7 +59,8 @@ def _resolve_credentials(api_key: str | None, host_url: str | None) -> tuple[str
         if client is not None:
             api_key = api_key if api_key is not None else client.api_key
             host_url = host_url if host_url is not None else client.host_url
-    return api_key or "", host_url or ""
+    eval_base = os.environ.get("TRACEROOT_EVAL_API_URL") or host_url
+    return api_key or "", eval_base or ""
 
 
 def _http_json(method: str, url: str, api_key: str, body: dict | None = None) -> dict:

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -22,6 +22,7 @@ import json
 import urllib.error
 import urllib.request
 from typing import Any
+from urllib.parse import quote
 
 from traceroot.eval.results import EvalItemResult, UploadState
 from traceroot.eval.transport import PublishResult, RunHandle
@@ -403,7 +404,7 @@ def pull_dataset(
         )
     host = host.rstrip("/")
 
-    meta = _http_get_json(f"{host}/api/v1/public/datasets/{dataset_id}", key)
+    meta = _http_get_json(f"{host}/api/v1/public/datasets/{quote(dataset_id, safe='')}", key)
     name = meta.get("name", dataset_id)
     if version_id is None:
         version_id = meta["current_dataset_version_id"]
@@ -439,7 +440,9 @@ def pull_dataset_version(
     host = host.rstrip("/")
 
     try:
-        snapshot = _http_get_json(f"{host}/api/v1/public/dataset-versions/{version_id}", key)
+        snapshot = _http_get_json(
+            f"{host}/api/v1/public/dataset-versions/{quote(version_id, safe='')}", key
+        )
     except RuntimeError as exc:
         if " HTTP 404:" in str(exc):
             raise ValueError(f"dataset version {version_id!r} not found") from exc

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -259,28 +259,11 @@ class PlatformTransport:
         return ("passed" if main >= self.pass_threshold else "failed"), main
 
 
-def pull_dataset(
-    dataset_id: str, *, api_key: str | None = None, host_url: str | None = None
-) -> Dataset:
-    """Fetch a platform dataset's current snapshot into a local :class:`Dataset`.
-
-    The returned Dataset carries ``dataset_id`` / ``dataset_version_id`` so that
-    ``evaluate(data=dataset, ...)`` reports back to the exact same dataset version.
-    """
-    key, host = _resolve_credentials(api_key, host_url)
-    if not key:
-        raise ValueError(
-            "pull_dataset needs an API key (initialize traceroot or pass api_key=...)."
-        )
-    host = host.rstrip("/")
-
-    meta = _http_get_json(f"{host}/api/v1/public/datasets/{dataset_id}", key)
-    version_id = meta["current_dataset_version_id"]
-    snapshot = _http_get_json(f"{host}/api/v1/public/dataset-versions/{version_id}", key)
-
-    ds = Dataset(name=meta.get("name", dataset_id))
-    ds.dataset_id = dataset_id
-    ds.dataset_version_id = version_id
+def _dataset_from_version(snapshot: dict, name: str) -> Dataset:
+    """Build a local Dataset pinned to the exact version described by ``snapshot``."""
+    ds = Dataset(name=name)
+    ds.dataset_id = snapshot.get("dataset_id")  # type: ignore[assignment]
+    ds.dataset_version_id = snapshot.get("dataset_version_id")
     for item in snapshot.get("items", []):
         # Native JSON at the HTTP boundary: the backend already JSON-decodes
         # input/expected before returning them, so the SDK takes the values as-is.
@@ -295,4 +278,75 @@ def pull_dataset(
                 source_span_id=item.get("source_span_id"),
             )
         )
+    return ds
+
+
+def pull_dataset(
+    dataset_id: str,
+    *,
+    version_id: str | None = None,
+    api_key: str | None = None,
+    host_url: str | None = None,
+) -> Dataset:
+    """Fetch a platform dataset into a local :class:`Dataset`.
+
+    Without ``version_id`` the dataset's CURRENT version is pulled. With ``version_id``
+    that EXACT immutable version is pulled and validated to belong to ``dataset_id`` --
+    the current version is never silently substituted, so a run can reproduce the precise
+    version it recorded. The returned Dataset carries ``dataset_id`` / ``dataset_version_id``.
+    """
+    key, host = _resolve_credentials(api_key, host_url)
+    if not key:
+        raise ValueError(
+            "pull_dataset needs an API key (initialize traceroot or pass api_key=...)."
+        )
+    host = host.rstrip("/")
+
+    meta = _http_get_json(f"{host}/api/v1/public/datasets/{dataset_id}", key)
+    name = meta.get("name", dataset_id)
+    if version_id is None:
+        version_id = meta["current_dataset_version_id"]
+    return pull_dataset_version(
+        version_id, dataset_id=dataset_id, name=name, api_key=key, host_url=host
+    )
+
+
+def pull_dataset_version(
+    version_id: str,
+    *,
+    dataset_id: str | None = None,
+    name: str | None = None,
+    api_key: str | None = None,
+    host_url: str | None = None,
+) -> Dataset:
+    """Fetch one EXACT immutable dataset version by its id.
+
+    When ``dataset_id`` is supplied, the returned version is validated to belong to it
+    (a mismatch raises ``ValueError`` rather than silently returning the wrong data).
+    A missing version surfaces the backend's 404 as a clear error.
+    """
+    key, host = _resolve_credentials(api_key, host_url)
+    if not key:
+        raise ValueError(
+            "pull_dataset_version needs an API key (initialize traceroot or pass api_key=...)."
+        )
+    host = host.rstrip("/")
+
+    try:
+        snapshot = _http_get_json(f"{host}/api/v1/public/dataset-versions/{version_id}", key)
+    except RuntimeError as exc:
+        if " HTTP 404:" in str(exc):
+            raise ValueError(f"dataset version {version_id!r} not found") from exc
+        raise
+
+    returned_dataset_id = snapshot.get("dataset_id")
+    if dataset_id is not None and returned_dataset_id not in (None, dataset_id):
+        raise ValueError(
+            f"dataset version {version_id!r} belongs to dataset {returned_dataset_id!r}, "
+            f"not {dataset_id!r}"
+        )
+    ds = _dataset_from_version(snapshot, name or returned_dataset_id or dataset_id or version_id)
+    # Pin ids even if the snapshot omitted them.
+    ds.dataset_version_id = ds.dataset_version_id or version_id
+    ds.dataset_id = ds.dataset_id or dataset_id  # type: ignore[assignment]
     return ds

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -42,45 +42,14 @@ def _as_text(value: Any) -> str | None:
     return json.dumps(serialize_value(value))
 
 
-# --- canonical codec for a dataset case's ``input`` / ``expected`` -----------
-# The backend stores these in a TEXT column with no type marker and never parses
-# them on read (see offline-eval/contract-notes/dataset-json-roundtrip.md). Its
-# ``toText`` stores an SDK-sent STRING verbatim and JSON-stringifies anything else.
-# So the ONLY way to preserve the original value's type across a round trip is for
-# the SDK to own a canonical encoding on BOTH ends: always send JSON text on push
-# (``_encode_field``) and always JSON-decode on pull (``_decode_field``). This makes
-# a genuine string survive as a string even when it contains JSON-looking text
-# (it is stored as ``"{...}"`` with quotes), which a bare ``json.loads`` of the raw
-# column could not guarantee.
-
-
-def _encode_field(value: Any) -> str:
-    """Canonical push encoding for a case's ``input``/``expected``: JSON text.
-
-    Emitting JSON text (a string) means the backend's TEXT column stores it
-    verbatim, so ``_decode_field`` is an exact inverse for every JSON type -- dict,
-    list, number, bool, null, and genuine strings (including JSON-looking ones).
-    A dict still serializes to the same bytes the backend produced before, so
-    already-published dict data keeps round-tripping.
-    """
-    return json.dumps(serialize_value(value))
-
-
-def _decode_field(value: Any) -> Any:
-    """Pull decoding: the exact inverse of :func:`_encode_field`.
-
-    ``metadata`` (a native JSONB column) arrives already parsed and is passed
-    through untouched. For ``input``/``expected`` the backend returns the stored
-    text; ``json.loads`` reconstructs the original value. A value that is already
-    native, or legacy text a foreign writer stored without canonical encoding
-    (e.g. a bare non-JSON string), is returned unchanged.
-    """
-    if not isinstance(value, str):
-        return value
-    try:
-        return json.loads(value)
-    except (ValueError, TypeError):
-        return value
+# NOTE: dataset case ``input``/``expected``/``metadata`` cross the HTTP boundary as
+# NATIVE JSON values. The backend owns the single JSON encode/decode at its storage
+# column (dataset authoring schema is ``z.unknown()``; the pull route JSON-decodes
+# before returning). The SDK must NOT add its own json.dumps/json.loads for these --
+# that would double-encode/decode and corrupt genuine JSON-looking strings. Explicit
+# JSON text is retained only where the wire genuinely requires a string: the
+# evaluation-RESULT reporting fields (``_as_text``) and local file persistence
+# (``Dataset.save``/``EvalRunResult.save``).
 
 
 def _resolve_credentials(api_key: str | None, host_url: str | None) -> tuple[str, str]:
@@ -313,11 +282,14 @@ def pull_dataset(
     ds.dataset_id = dataset_id
     ds.dataset_version_id = version_id
     for item in snapshot.get("items", []):
+        # Native JSON at the HTTP boundary: the backend already JSON-decodes
+        # input/expected before returning them, so the SDK takes the values as-is.
+        # Re-decoding here would double-decode a genuine JSON-looking string.
         ds.upsert(
             EvalCase(
                 id=item["test_case_id"],
-                input=_decode_field(item["input"]),
-                expected=_decode_field(item.get("expected")),
+                input=item["input"],
+                expected=item.get("expected"),
                 metadata=item.get("metadata"),
                 source_trace_id=item.get("source_trace_id"),
                 source_span_id=item.get("source_span_id"),

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -154,7 +154,8 @@ class PlatformTransport:
             )
         self.host_url = self.host_url.rstrip("/")
         self.run_id: str | None = None
-        self.run_path: str | None = None  # UI-relative run path, when the backend returns one
+        self.run_url: str | None = None  # absolute UI run link, when the backend returns one
+        self.run_path: str | None = None  # UI-relative run path (back-compat fallback)
         self._scored = 0
         self._task_errors = 0
         self._scorer_errors = 0
@@ -190,7 +191,10 @@ class PlatformTransport:
             body["client_run_id"] = effective_crun
         resp = self._request("POST", "/api/v1/public/evaluation-runs", body)
         self.run_id = resp["evaluation_run_id"]
-        # Optional: absent on older/self-hosted backends -> dashboard_url stays None.
+        # Optional, absent on older/self-hosted backends. Prefer the absolute run_url
+        # (resolved against the UI origin) so the link is correct even when the API and
+        # UI live on different origins; keep run_path as a same-origin fallback.
+        self.run_url = resp.get("run_url")
         self.run_path = resp.get("run_path")
         return RunHandle(name=name, dataset_name=dataset_name, metadata=metadata)
 
@@ -299,7 +303,9 @@ class PlatformTransport:
         )
         # Join the backend's UI-relative run path with our host to form a clickable
         # link; None when the backend did not return one (older/self-hosted).
-        url = f"{self.host_url}{self.run_path}" if self.run_path else None
+        # Prefer the backend's absolute run_url; fall back to host_url + run_path for a
+        # control plane that predates run_url (keeps the same-origin behavior).
+        url = self.run_url or (f"{self.host_url}{self.run_path}" if self.run_path else None)
         return UploadState(status="uploaded", dashboard_url=url)
 
     def publish_dataset(self, dataset_name: str, item_count: int) -> PublishResult:

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -49,6 +49,14 @@ def _as_text(value: Any) -> str | None:
     return json.dumps(serialize_value(value))
 
 
+def _duration_ms(value: float | None) -> int | None:
+    """Per-case wall-clock duration for the wire: a nonnegative INTEGer of milliseconds
+    (backend ``z.number().int().nonnegative()``). Unknown stays None -- never 0."""
+    if value is None:
+        return None
+    return max(0, round(value))
+
+
 # NOTE: dataset case ``input``/``expected``/``metadata`` cross the HTTP boundary as
 # NATIVE JSON values. The backend owns the single JSON encode/decode at its storage
 # column (dataset authoring schema is ``z.unknown()``; the pull route JSON-decodes
@@ -215,6 +223,9 @@ class PlatformTransport:
                 "status": status,
                 "main_score": main_score,
                 "task_error": item_result.error,
+                # Total wall-clock for this case (task + its scorers); nonneg int ms, null
+                # when unknown. Run duration is NOT summed from cases (they run concurrently).
+                "duration_ms": _duration_ms(item_result.duration_ms),
                 "scores": self._scores_payload(item_result),
             },
         )

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -131,6 +131,8 @@ def _http_get_json(url: str, api_key: str) -> dict:
 class PlatformTransport:
     """Reports an evaluation run to the TraceRoot backend. One instance per run."""
 
+    reports_traces = True  # a reported run exports its per-case evaluation traces
+
     def __init__(
         self,
         dataset_id: str,

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -86,7 +86,9 @@ def _resolve_credentials(api_key: str | None, host_url: str | None) -> tuple[str
 
 
 def _http_json(method: str, url: str, api_key: str, body: dict | None = None) -> dict:
-    data = json.dumps(body).encode() if body is not None else None
+    # Serialize the body consistently (like _json_dumps) so valid but non-JSON-native SDK metadata
+    # doesn't fail locally with a TypeError before the request is even sent.
+    data = json.dumps(serialize_value(body)).encode() if body is not None else None
     req = urllib.request.Request(url, data=data, method=method)
     req.add_header("Authorization", f"Bearer {api_key}")
     if data is not None:
@@ -338,12 +340,21 @@ class PlatformTransport:
             if s.comment is not None:
                 entry["explanation"] = s.comment
             payload.append(entry)
-        # A failing scorer is a score with an error and null value (never 0).
+        # A failing scorer is a score with an error and null value (never 0). Use the scorer's
+        # DECLARED version (from the manifest) so an errored versioned scorer isn't misattributed
+        # to 'unversioned'.
         for name, msg in item_result.scorer_errors.items():
             payload.append(
-                {"scorer_name": name, "scorer_version": _UNVERSIONED_SCORER, "error": msg}
+                {"scorer_name": name, "scorer_version": self._declared_version(name), "error": msg}
             )
         return payload
+
+    def _declared_version(self, name: str) -> str:
+        """Declared manifest version for a scorer name, or the sentinel when none was declared."""
+        for spec in self.scorer_specs or []:
+            if spec.get("name") == name:
+                return spec.get("version") or _UNVERSIONED_SCORER
+        return _UNVERSIONED_SCORER
 
     def _status_and_main(self, item_result: EvalItemResult) -> tuple[str, float | None]:
         if item_result.error is not None:

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -161,8 +161,9 @@ class PlatformTransport:
                 "test_case_id": item_result.case_id,
                 "trace_id": item_result.trace_id,
                 # The backend validates these as strings (z.string()); serialize
-                # non-string values (dicts/numbers) to JSON text.
-                "input": _as_text(item_result.input),
+                # non-string values (dicts/numbers) to JSON text. `input` is a
+                # REQUIRED string (not nullable) -> coerce a missing input to "".
+                "input": _as_text(item_result.input) or "",
                 "expected_output": _as_text(item_result.expected),
                 "candidate_output": _as_text(item_result.output),
                 "status": status,

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -1,0 +1,259 @@
+"""Platform reporting transport for offline evaluation.
+
+Implements the ``EvalTransport`` seam against the TraceRoot backend's offline-eval
+reporting endpoints (see the backend ``offline-eval-sdk-contract.md``):
+
+    POST /api/public/evaluation-runs                    (register/start a run)
+    POST /api/public/evaluation-runs/{id}/results       (upsert one result + scores)
+    POST /api/public/evaluation-runs/{id}/complete      (finish a run)
+    GET  /api/public/datasets/{id}                       (fetch dataset -> version id)
+    GET  /api/public/dataset-versions/{id}               (fetch immutable snapshot)
+
+Auth is ``Authorization: Bearer <api_key>`` (an existing project Access Key) - the
+same credential and host as trace ingestion. Uses only the standard library.
+
+The SDK is reporting-only by contract: the server owns dataset_id / test_case_id /
+dataset_version_id, so datasets are FETCHED (``pull_dataset``), not created here.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from traceroot.eval.results import EvalItemResult, UploadState
+from traceroot.eval.transport import PublishResult, RunHandle
+from traceroot.eval.types import Dataset, EvalCase, Score
+from traceroot.utils import serialize_value
+
+_DEFAULT_PASS_THRESHOLD = 1.0
+
+
+def _as_text(value: Any) -> str | None:
+    """Coerce a value to a string for the backend's z.string() fields.
+
+    Strings pass through as-is; None stays None (for nullable fields); everything
+    else is JSON-encoded (dicts/lists/numbers become their JSON text).
+    """
+    if value is None or isinstance(value, str):
+        return value
+    return json.dumps(serialize_value(value))
+
+
+def _resolve_credentials(api_key: str | None, host_url: str | None) -> tuple[str, str]:
+    """Fill api_key/host_url from the global client when not explicitly given."""
+    if api_key is None or host_url is None:
+        from traceroot import get_client
+
+        client = get_client()
+        if client is not None:
+            api_key = api_key if api_key is not None else client.api_key
+            host_url = host_url if host_url is not None else client.host_url
+    return api_key or "", host_url or ""
+
+
+def _http_json(method: str, url: str, api_key: str, body: dict | None = None) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {api_key}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        raise RuntimeError(f"{method} {url} -> HTTP {exc.code}: {detail}") from exc
+
+
+def _http_get_json(url: str, api_key: str) -> dict:
+    return _http_json("GET", url, api_key)
+
+
+class PlatformTransport:
+    """Reports an evaluation run to the TraceRoot backend. One instance per run."""
+
+    def __init__(
+        self,
+        dataset_id: str,
+        *,
+        scorer_names: list[str] | None = None,
+        candidate_version: str | None = None,
+        environment: str = "evaluation",
+        main_score_name: str | None = None,
+        dataset_version_id: str | None = None,
+        client_run_id: str | None = None,
+        pass_threshold: float = _DEFAULT_PASS_THRESHOLD,
+        api_key: str | None = None,
+        host_url: str | None = None,
+    ) -> None:
+        self.dataset_id = dataset_id
+        self.scorer_names = scorer_names or []
+        self.candidate_version = candidate_version or "sdk"
+        self.environment = environment
+        self.main_score_name = main_score_name or (
+            self.scorer_names[0] if self.scorer_names else None
+        )
+        self.dataset_version_id = dataset_version_id
+        self.client_run_id = client_run_id
+        self.pass_threshold = pass_threshold
+        self.api_key, self.host_url = _resolve_credentials(api_key, host_url)
+        if not self.api_key:
+            raise ValueError(
+                "PlatformTransport needs an API key. Call traceroot.initialize(api_key=...) "
+                "or pass api_key=... (uploading requires credentials)."
+            )
+        self.host_url = self.host_url.rstrip("/")
+        self.run_id: str | None = None
+        self._scored = 0
+        self._task_errors = 0
+        self._scorer_errors = 0
+
+    # --- HTTP seam (overridable in tests) ---
+    def _request(self, method: str, path: str, body: dict | None = None) -> dict:
+        return _http_json(method, f"{self.host_url}{path}", self.api_key, body)
+
+    # --- EvalTransport protocol ---
+    def create_run(self, name: str, dataset_name: str, metadata: dict | None) -> RunHandle:
+        body: dict[str, Any] = {
+            "evaluation_name": name,
+            "dataset_id": self.dataset_id,
+            "candidate_version": self.candidate_version,
+            "environment": self.environment,
+            "scorers": [{"name": n, "version": "1"} for n in self.scorer_names],
+        }
+        if self.dataset_version_id is not None:
+            body["dataset_version_id"] = self.dataset_version_id
+        if self.main_score_name is not None:
+            body["main_score_name"] = self.main_score_name
+        if self.client_run_id is not None:
+            body["client_run_id"] = self.client_run_id
+        resp = self._request("POST", "/api/public/evaluation-runs", body)
+        self.run_id = resp["evaluation_run_id"]
+        return RunHandle(name=name, dataset_name=dataset_name, metadata=metadata)
+
+    def register_item(self, run: RunHandle, case: EvalCase) -> None:
+        # The item->trace link is folded into the result upsert (contract), so no-op.
+        return None
+
+    def record_item_result(self, run: RunHandle, item_result: EvalItemResult) -> None:
+        status, main_score = self._status_and_main(item_result)
+        if status == "errored":
+            self._task_errors += 1
+        elif status in ("passed", "failed"):
+            self._scored += 1
+        self._scorer_errors += len(item_result.scorer_errors)
+        self._request(
+            "POST",
+            f"/api/public/evaluation-runs/{self.run_id}/results",
+            {
+                "test_case_id": item_result.case_id,
+                "trace_id": item_result.trace_id,
+                # The backend validates these as strings (z.string()); serialize
+                # non-string values (dicts/numbers) to JSON text.
+                "input": _as_text(item_result.input),
+                "expected_output": _as_text(item_result.expected),
+                "candidate_output": _as_text(item_result.output),
+                "status": status,
+                "main_score": main_score,
+                "task_error": item_result.error,
+                "scores": self._scores_payload(item_result),
+            },
+        )
+
+    def record_scores(self, run: RunHandle, case_id: str, scores: list[Score]) -> None:
+        # Already sent inside record_item_result (which carries the full item).
+        return None
+
+    def finish_run(self, run: RunHandle) -> UploadState:
+        self._request(
+            "POST",
+            f"/api/public/evaluation-runs/{self.run_id}/complete",
+            {
+                "status": "completed_with_errors"
+                if (self._task_errors or self._scorer_errors)
+                else "completed",
+                "scored_count": self._scored,
+                "task_error_count": self._task_errors,
+                "scorer_error_count": self._scorer_errors,
+            },
+        )
+        # The backend returns no dashboard URL; report uploaded with url unknown.
+        return UploadState(status="uploaded", dashboard_url=None)
+
+    def publish_dataset(self, dataset_name: str, item_count: int) -> PublishResult:
+        # Datasets are server/UI-owned; the SDK cannot create them. Stay local-only.
+        return PublishResult(status="local_only", dataset_name=dataset_name, item_count=item_count)
+
+    # --- mapping helpers ---
+    def _scores_payload(self, item_result: EvalItemResult) -> list[dict]:
+        payload: list[dict] = []
+        for s in item_result.scores:
+            entry: dict[str, Any] = {"scorer_name": s.name, "scorer_version": "1"}
+            v = s.value
+            if isinstance(v, bool):
+                entry["bool_value"] = v
+            elif isinstance(v, (int, float)):
+                entry["numeric_value"] = float(v)
+            else:
+                entry["string_value"] = str(v)
+            if s.comment is not None:
+                entry["explanation"] = s.comment
+            payload.append(entry)
+        # A failing scorer is a score with an error and null value (never 0).
+        for name, msg in item_result.scorer_errors.items():
+            payload.append({"scorer_name": name, "scorer_version": "1", "error": msg})
+        return payload
+
+    def _status_and_main(self, item_result: EvalItemResult) -> tuple[str, float | None]:
+        if item_result.error is not None:
+            return "errored", None
+        main = None
+        for s in item_result.scores:
+            if isinstance(s.value, bool) or not isinstance(s.value, (int, float)):
+                continue
+            if self.main_score_name is None or s.name == self.main_score_name:
+                main = float(s.value)
+                break
+        if main is None:
+            return "not_scored", None
+        return ("passed" if main >= self.pass_threshold else "failed"), main
+
+
+def pull_dataset(
+    dataset_id: str, *, api_key: str | None = None, host_url: str | None = None
+) -> Dataset:
+    """Fetch a platform dataset's current snapshot into a local :class:`Dataset`.
+
+    The returned Dataset carries ``dataset_id`` / ``dataset_version_id`` so that
+    ``evaluate(data=dataset, ...)`` reports back to the exact same dataset version.
+    """
+    key, host = _resolve_credentials(api_key, host_url)
+    if not key:
+        raise ValueError(
+            "pull_dataset needs an API key (initialize traceroot or pass api_key=...)."
+        )
+    host = host.rstrip("/")
+
+    meta = _http_get_json(f"{host}/api/public/datasets/{dataset_id}", key)
+    version_id = meta["current_dataset_version_id"]
+    snapshot = _http_get_json(f"{host}/api/public/dataset-versions/{version_id}", key)
+
+    ds = Dataset(name=meta.get("name", dataset_id))
+    ds.dataset_id = dataset_id
+    ds.dataset_version_id = version_id
+    for item in snapshot.get("items", []):
+        ds.upsert(
+            EvalCase(
+                id=item["test_case_id"],
+                input=item["input"],
+                expected=item.get("expected"),
+                metadata=item.get("metadata"),
+                source_trace_id=item.get("source_trace_id"),
+                source_span_id=item.get("source_span_id"),
+            )
+        )
+    return ds

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -118,6 +118,7 @@ class PlatformTransport:
         environment: str = "evaluation",
         main_score_name: str | None = None,
         dataset_version_id: str | None = None,
+        baseline_run_id: str | None = None,
         client_run_id: str | None = None,
         pass_threshold: float = _DEFAULT_PASS_THRESHOLD,
         api_key: str | None = None,
@@ -131,6 +132,9 @@ class PlatformTransport:
             self.scorer_names[0] if self.scorer_names else None
         )
         self.dataset_version_id = dataset_version_id
+        # Links this run to a baseline run so the platform/UI can show the comparison
+        # (Change / regressions). Without it a reported run shows "No baseline".
+        self.baseline_run_id = baseline_run_id
         self.client_run_id = client_run_id
         self.pass_threshold = pass_threshold
         self.api_key, self.host_url = _resolve_credentials(api_key, host_url)
@@ -170,6 +174,8 @@ class PlatformTransport:
             body["dataset_version_id"] = self.dataset_version_id
         if self.main_score_name is not None:
             body["main_score_name"] = self.main_score_name
+        if self.baseline_run_id is not None:
+            body["baseline_run_id"] = self.baseline_run_id
         # Idempotency key: prefer the one the RunSession drives with, else our own.
         effective_crun = client_run_id or self.client_run_id
         if effective_crun is not None:

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -115,8 +115,6 @@ def _http_get_json(url: str, api_key: str) -> dict:
 class PlatformTransport:
     """Reports an evaluation run to the TraceRoot backend. One instance per run."""
 
-    reports_traces = True  # a reported run exports its per-case evaluation traces
-
     def __init__(
         self,
         dataset_id: str,
@@ -185,7 +183,7 @@ class PlatformTransport:
             body["dataset_version_id"] = self.dataset_version_id
         if self.main_score_name is not None:
             body["main_score_name"] = self.main_score_name
-        # Idempotency key: prefer the one the RunSession drives with, else our own.
+        # Idempotency key: prefer the one the caller drives with, else our own.
         effective_crun = client_run_id or self.client_run_id
         if effective_crun is not None:
             body["client_run_id"] = effective_crun

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -117,7 +117,13 @@ class PlatformTransport:
         return _http_json(method, f"{self.host_url}{path}", self.api_key, body)
 
     # --- EvalTransport protocol ---
-    def create_run(self, name: str, dataset_name: str, metadata: dict | None) -> RunHandle:
+    def create_run(
+        self,
+        name: str,
+        dataset_name: str,
+        metadata: dict | None,
+        client_run_id: str | None = None,
+    ) -> RunHandle:
         body: dict[str, Any] = {
             "evaluation_name": name,
             "dataset_id": self.dataset_id,
@@ -129,8 +135,10 @@ class PlatformTransport:
             body["dataset_version_id"] = self.dataset_version_id
         if self.main_score_name is not None:
             body["main_score_name"] = self.main_score_name
-        if self.client_run_id is not None:
-            body["client_run_id"] = self.client_run_id
+        # Idempotency key: prefer the one the RunSession drives with, else our own.
+        effective_crun = client_run_id or self.client_run_id
+        if effective_crun is not None:
+            body["client_run_id"] = effective_crun
         resp = self._request("POST", "/api/public/evaluation-runs", body)
         self.run_id = resp["evaluation_run_id"]
         return RunHandle(name=name, dataset_name=dataset_name, metadata=metadata)

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -280,10 +280,16 @@ class PlatformTransport:
             return "errored", None
         main = None
         for s in item_result.scores:
-            if isinstance(s.value, bool) or not isinstance(s.value, (int, float)):
+            if self.main_score_name is not None and s.name != self.main_score_name:
                 continue
-            if self.main_score_name is None or s.name == self.main_score_name:
+            if isinstance(s.value, bool):  # bool before int: True->1.0, False->0.0
+                main = 1.0 if s.value else 0.0
+                break
+            if isinstance(s.value, (int, float)):
                 main = float(s.value)
+                break
+            if self.main_score_name is not None:
+                # The named main scorer produced a categorical value -> no numeric main.
                 break
         if main is None:
             return "not_scored", None

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -30,6 +30,13 @@ from traceroot.utils import serialize_value
 
 _DEFAULT_PASS_THRESHOLD = 1.0
 
+# The backend's public contract requires a NON-EMPTY scorer version string
+# (ScorerRefSchema/ScoreInputSchema: z.string().min(1)). The SDK data model and the
+# CLI event/artifact path stay honest with version=None for an unversioned scorer;
+# only at this reporting boundary do we map None -> an explicit "unversioned" sentinel
+# so the request validates. This is a clear marker, not an invented version number.
+_UNVERSIONED_SCORER = "unversioned"
+
 
 def _as_text(value: Any) -> str | None:
     """Coerce a value to a string for the backend's z.string() fields.
@@ -155,9 +162,9 @@ class PlatformTransport:
             "dataset_id": self.dataset_id,
             "candidate_version": self.candidate_version,
             "environment": self.environment,
-            # The transport only knows scorer names, not declared versions -> null,
-            # never an invented "1".
-            "scorers": [{"name": n, "version": None} for n in self.scorer_names],
+            # The transport only knows scorer names, not declared versions. The backend
+            # requires a non-empty version string, so unversioned scorers use the sentinel.
+            "scorers": [{"name": n, "version": _UNVERSIONED_SCORER} for n in self.scorer_names],
         }
         if self.dataset_version_id is not None:
             body["dataset_version_id"] = self.dataset_version_id
@@ -230,8 +237,11 @@ class PlatformTransport:
     def _scores_payload(self, item_result: EvalItemResult) -> list[dict]:
         payload: list[dict] = []
         for s in item_result.scores:
-            # Honest scorer version: the score's declared version (None if unversioned).
-            entry: dict[str, Any] = {"scorer_name": s.name, "scorer_version": s.version}
+            # Declared version when present; sentinel where the backend requires a string.
+            entry: dict[str, Any] = {
+                "scorer_name": s.name,
+                "scorer_version": s.version or _UNVERSIONED_SCORER,
+            }
             v = s.value
             if isinstance(v, bool):
                 entry["bool_value"] = v
@@ -244,7 +254,9 @@ class PlatformTransport:
             payload.append(entry)
         # A failing scorer is a score with an error and null value (never 0).
         for name, msg in item_result.scorer_errors.items():
-            payload.append({"scorer_name": name, "scorer_version": None, "error": msg})
+            payload.append(
+                {"scorer_name": name, "scorer_version": _UNVERSIONED_SCORER, "error": msg}
+            )
         return payload
 
     def _status_and_main(self, item_result: EvalItemResult) -> tuple[str, float | None]:

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -3,11 +3,11 @@
 Implements the ``EvalTransport`` seam against the TraceRoot backend's offline-eval
 reporting endpoints (see the backend ``offline-eval-sdk-contract.md``):
 
-    POST /api/public/evaluation-runs                    (register/start a run)
-    POST /api/public/evaluation-runs/{id}/results       (upsert one result + scores)
-    POST /api/public/evaluation-runs/{id}/complete      (finish a run)
-    GET  /api/public/datasets/{id}                       (fetch dataset -> version id)
-    GET  /api/public/dataset-versions/{id}               (fetch immutable snapshot)
+    POST /api/v1/public/evaluation-runs                    (register/start a run)
+    POST /api/v1/public/evaluation-runs/{id}/results       (upsert one result + scores)
+    POST /api/v1/public/evaluation-runs/{id}/complete      (finish a run)
+    GET  /api/v1/public/datasets/{id}                       (fetch dataset -> version id)
+    GET  /api/v1/public/dataset-versions/{id}               (fetch immutable snapshot)
 
 Auth is ``Authorization: Bearer <api_key>`` (an existing project Access Key) - the
 same credential and host as trace ingestion. Uses only the standard library.
@@ -19,7 +19,6 @@ dataset_version_id, so datasets are FETCHED (``pull_dataset``), not created here
 from __future__ import annotations
 
 import json
-import os
 import urllib.error
 import urllib.request
 from typing import Any
@@ -44,13 +43,11 @@ def _as_text(value: Any) -> str | None:
 
 
 def _resolve_credentials(api_key: str | None, host_url: str | None) -> tuple[str, str]:
-    """Resolve (api_key, eval_api_base) for the ``/api/public/*`` endpoints.
+    """Fill api_key/host_url from the global client when not explicitly given.
 
-    api_key/host_url fall back to the global client. The eval endpoints
-    (``/api/public/*``) live in the TraceRoot app; in production that is the same
-    origin as tracing, but in local dev the app (Next.js) and the trace-ingest
-    backend (Python) run on different ports. ``TRACEROOT_EVAL_API_URL`` overrides the
-    base for eval calls only (traces are unaffected); unset -> use host_url.
+    The eval endpoints are served by the Python backend under ``/api/v1/public/*``
+    (a proxy to the app) - the SAME host as trace ingestion - so a single
+    ``host_url`` reaches both traces and eval calls.
     """
     if api_key is None or host_url is None:
         from traceroot import get_client
@@ -59,8 +56,7 @@ def _resolve_credentials(api_key: str | None, host_url: str | None) -> tuple[str
         if client is not None:
             api_key = api_key if api_key is not None else client.api_key
             host_url = host_url if host_url is not None else client.host_url
-    eval_base = os.environ.get("TRACEROOT_EVAL_API_URL") or host_url
-    return api_key or "", eval_base or ""
+    return api_key or "", host_url or ""
 
 
 def _http_json(method: str, url: str, api_key: str, body: dict | None = None) -> dict:
@@ -148,7 +144,7 @@ class PlatformTransport:
         effective_crun = client_run_id or self.client_run_id
         if effective_crun is not None:
             body["client_run_id"] = effective_crun
-        resp = self._request("POST", "/api/public/evaluation-runs", body)
+        resp = self._request("POST", "/api/v1/public/evaluation-runs", body)
         self.run_id = resp["evaluation_run_id"]
         return RunHandle(name=name, dataset_name=dataset_name, metadata=metadata)
 
@@ -165,7 +161,7 @@ class PlatformTransport:
         self._scorer_errors += len(item_result.scorer_errors)
         self._request(
             "POST",
-            f"/api/public/evaluation-runs/{self.run_id}/results",
+            f"/api/v1/public/evaluation-runs/{self.run_id}/results",
             {
                 "test_case_id": item_result.case_id,
                 "trace_id": item_result.trace_id,
@@ -192,7 +188,7 @@ class PlatformTransport:
         )
         self._request(
             "POST",
-            f"/api/public/evaluation-runs/{self.run_id}/complete",
+            f"/api/v1/public/evaluation-runs/{self.run_id}/complete",
             {
                 "status": effective,
                 "scored_count": self._scored,
@@ -257,9 +253,9 @@ def pull_dataset(
         )
     host = host.rstrip("/")
 
-    meta = _http_get_json(f"{host}/api/public/datasets/{dataset_id}", key)
+    meta = _http_get_json(f"{host}/api/v1/public/datasets/{dataset_id}", key)
     version_id = meta["current_dataset_version_id"]
-    snapshot = _http_get_json(f"{host}/api/public/dataset-versions/{version_id}", key)
+    snapshot = _http_get_json(f"{host}/api/v1/public/dataset-versions/{version_id}", key)
 
     ds = Dataset(name=meta.get("name", dataset_id))
     ds.dataset_id = dataset_id

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -148,6 +148,8 @@ class PlatformTransport:
         self._scored = 0
         self._task_errors = 0
         self._scorer_errors = 0
+        self._main_sum = 0.0  # aggregate of the main-score values for run.mainScore
+        self._main_count = 0
 
     # --- HTTP seam (overridable in tests) ---
     def _request(self, method: str, path: str, body: dict | None = None) -> dict:
@@ -194,6 +196,9 @@ class PlatformTransport:
             self._task_errors += 1
         elif status in ("passed", "failed"):
             self._scored += 1
+        if main_score is not None:
+            self._main_sum += main_score
+            self._main_count += 1
         self._scorer_errors += len(item_result.scorer_errors)
         self._request(
             "POST",
@@ -222,15 +227,20 @@ class PlatformTransport:
         effective = status or (
             "completed_with_errors" if (self._task_errors or self._scorer_errors) else "completed"
         )
+        body: dict[str, Any] = {
+            "status": effective,
+            "scored_count": self._scored,
+            "task_error_count": self._task_errors,
+            "scorer_error_count": self._scorer_errors,
+        }
+        # The run's aggregate main score -> run.mainScore. Without it the UI shows the
+        # main metric and the baseline delta as "-" (change = run.mainScore - baseline).
+        if self._main_count:
+            body["main_score"] = self._main_sum / self._main_count
         self._request(
             "POST",
             f"/api/v1/public/evaluation-runs/{self.run_id}/complete",
-            {
-                "status": effective,
-                "scored_count": self._scored,
-                "task_error_count": self._task_errors,
-                "scorer_error_count": self._scorer_errors,
-            },
+            body,
         )
         # The backend returns no dashboard URL; report uploaded with url unknown.
         return UploadState(status="uploaded", dashboard_url=None)

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -71,6 +71,15 @@ def _http_json(method: str, url: str, api_key: str, body: dict | None = None) ->
             return json.loads(raw) if raw else {}
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode(errors="replace")
+        location = exc.headers.get("Location", "") if exc.headers else ""
+        blob = f"{location} {detail}".lower()
+        if exc.code in (301, 302, 303, 307, 308) and ("sign-in" in blob or "/auth/" in blob):
+            raise RuntimeError(
+                f"{method} {url} -> HTTP {exc.code} redirect to sign-in. The API key was not "
+                "honored: the backend's /api/public route is behind the app's session gate. "
+                "The app auth middleware must exempt /api/public (server-side fix; not the SDK "
+                "or your key)."
+            ) from exc
         raise RuntimeError(f"{method} {url} -> HTTP {exc.code}: {detail}") from exc
 
 

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -206,7 +206,21 @@ class PlatformTransport:
                     "name": spec["name"],
                     "version": spec.get("version") or _UNVERSIONED_SCORER,
                 }
-                for k in ("value_type", "direction", "threshold"):
+                # Comparison metadata + the read-only definition (scorer_type + type-specific
+                # fields). Absent fields are omitted, never null-filled.
+                for k in (
+                    "scorer_type",
+                    "value_type",
+                    "direction",
+                    "threshold",
+                    "output_type",
+                    "description",
+                    "metadata",
+                    "language",
+                    "source",
+                    "model",
+                    "messages",
+                ):
                     if spec.get(k) is not None:
                         ref[k] = spec[k]
                 refs.append(ref)

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -42,6 +42,23 @@ def _as_text(value: Any) -> str | None:
     return json.dumps(serialize_value(value))
 
 
+def _decode_field(value: Any) -> Any:
+    """Inverse of the backend's JSON-text storage for a dataset case's input/expected.
+
+    The backend persists these as JSON text and returns them as strings, so a
+    pushed dict must be decoded back to a dict (otherwise a task doing
+    ``input["message"]`` subscripts a str). ``json.loads`` is the exact inverse of
+    the stored ``json.dumps``; a value that is already native, or a plain string
+    the backend did not JSON-encode, is returned unchanged.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (ValueError, TypeError):
+        return value
+
+
 def _resolve_credentials(api_key: str | None, host_url: str | None) -> tuple[str, str]:
     """Fill api_key/host_url from the global client when not explicitly given.
 
@@ -273,8 +290,8 @@ def pull_dataset(
         ds.upsert(
             EvalCase(
                 id=item["test_case_id"],
-                input=item["input"],
-                expected=item.get("expected"),
+                input=_decode_field(item["input"]),
+                expected=_decode_field(item.get("expected")),
                 metadata=item.get("metadata"),
                 source_trace_id=item.get("source_trace_id"),
                 source_span_id=item.get("source_span_id"),

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -155,7 +155,9 @@ class PlatformTransport:
             "dataset_id": self.dataset_id,
             "candidate_version": self.candidate_version,
             "environment": self.environment,
-            "scorers": [{"name": n, "version": "1"} for n in self.scorer_names],
+            # The transport only knows scorer names, not declared versions -> null,
+            # never an invented "1".
+            "scorers": [{"name": n, "version": None} for n in self.scorer_names],
         }
         if self.dataset_version_id is not None:
             body["dataset_version_id"] = self.dataset_version_id
@@ -228,7 +230,8 @@ class PlatformTransport:
     def _scores_payload(self, item_result: EvalItemResult) -> list[dict]:
         payload: list[dict] = []
         for s in item_result.scores:
-            entry: dict[str, Any] = {"scorer_name": s.name, "scorer_version": "1"}
+            # Honest scorer version: the score's declared version (None if unversioned).
+            entry: dict[str, Any] = {"scorer_name": s.name, "scorer_version": s.version}
             v = s.value
             if isinstance(v, bool):
                 entry["bool_value"] = v
@@ -241,7 +244,7 @@ class PlatformTransport:
             payload.append(entry)
         # A failing scorer is a score with an error and null value (never 0).
         for name, msg in item_result.scorer_errors.items():
-            payload.append({"scorer_name": name, "scorer_version": "1", "error": msg})
+            payload.append({"scorer_name": name, "scorer_version": None, "error": msg})
         return payload
 
     def _status_and_main(self, item_result: EvalItemResult) -> tuple[str, float | None]:


### PR DESCRIPTION
## Summary

Adds the transport that reports an evaluation run to the platform over the public evaluation endpoints. A run is registered with a full scorer manifest, per-case results are upserted as they complete, and the run is finished with an aggregate main score. Registration returns a clickable run link, and a client-side run id makes registration idempotent so a retried run resolves to the same run instead of duplicating it. This also adds read-only dataset pulls so a run can reproduce the exact dataset version it scored.

Fixes: traceroot-ai/traceroot#1680

## How it works

```
register run  → POST /evaluation-runs            (scorer manifest + client_run_id)
per case      → POST /evaluation-runs/{id}/results   (status, main_score, duration, scores)
finish run    → POST /evaluation-runs/{id}/complete  (aggregate main_score + counts)
                → returns absolute run link (host + path fallback)
```

The client mints `client_run_id` up front and sends it on register; the backend treats it as the idempotency key. Result-reporting string fields are coerced to text (non-strings JSON-encoded), while dataset `input`/`expected` cross the boundary as native JSON so the backend owns the single encode/decode. Pass status uses an explicit pass threshold, else the main scorer's declared threshold, else a default of `1.0`; boolean main scores map to `1.0`/`0.0`.

## What's included

### Source
- `traceroot/eval/platform.py` — `PlatformTransport` (register → results → complete) implementing the `EvalTransport` seam over the stdlib HTTP client; builds the `scorers` manifest (name, version sentinel when unversioned, `scorer_type`, and the optional shared/code/llm-judge definition, absent fields omitted never null); aggregates the main score and resolves pass status against `_effective_threshold`. Also adds `pull_dataset` (current version) and `pull_dataset_version` (exact immutable version, validated to belong to the dataset) — read data, not runs.

### Tests
- `tests/eval/test_platform.py` — `PlatformTransport` wire payloads, dataset pull (native JSON, exact-version pin, mismatch, 404) with the HTTP seam stubbed in-memory.
- `tests/eval/test_reporting_ownership.py` — asserts the SDK sends raw outcomes only and no candidate-vs-baseline comparison linkage on the wire.
- `tests/eval/test_transport.py` — transport seam wiring and cloud-only default behavior.

## Test plan

- [ ] Register a run and confirm the manifest carries the full scorer definition; unknown fields are tolerated.
- [ ] Confirm per-case results carry status, main score, and duration, and the run finishes with the aggregate.
- [ ] Re-register with the same client run id and confirm it resolves to the same run, not a duplicate.
- [ ] Confirm the printed run link is the absolute link when present, and the host + path fallback otherwise.
- [ ] Pull a dataset at its current version and at an exact version id; confirm the exact version is never silently substituted.
