### PR TITLE
feat(eval): provenance, snippets, and local id minting

### DIFF
--- a/tests/eval/test_ids.py
+++ b/tests/eval/test_ids.py
@@ -1,0 +1,32 @@
+"""DS-1: client-generated stable ids (ULID with typed prefixes)."""
+
+import re
+
+from traceroot.eval.ids import new_dataset_id, new_run_id, new_test_case_id, ulid
+
+_ULID = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")  # Crockford base32, 26 chars
+
+
+def test_ulid_shape():
+    u = ulid()
+    assert _ULID.match(u), u
+
+
+def test_prefixes():
+    assert new_dataset_id().startswith("ds_")
+    assert new_test_case_id().startswith("tc_")
+    assert new_run_id().startswith("run_")
+    assert _ULID.match(new_dataset_id().split("_", 1)[1])
+
+
+def test_unique():
+    ids = {new_test_case_id() for _ in range(1000)}
+    assert len(ids) == 1000
+
+
+def test_time_sortable():
+    # ULIDs generated later sort >= earlier ones (millisecond time prefix).
+    a = ulid()
+    b = ulid()
+    # same-ms ties are allowed; never earlier-after-later beyond the random tail
+    assert a[:10] <= b[:10]

--- a/tests/eval/test_local_no_creds.py
+++ b/tests/eval/test_local_no_creds.py
@@ -1,0 +1,43 @@
+"""Cloud-only: evaluation with no credentials (and no explicit transport) raises.
+
+Runs in a fresh subprocess so no ambient TraceRoot credentials/provider are present - the
+true credential-free scenario. Evaluation reports to the platform, so without a way to
+report it must fail loudly rather than silently run locally.
+"""
+
+import os
+import subprocess
+import sys
+
+_SCRIPT = """
+import traceroot
+from traceroot.eval import Dataset, EvalCase, evaluate
+
+ds = Dataset(name="d")
+ds.upsert(EvalCase(input=2, id="c0", expected=2))
+
+
+def task(x):
+    return x
+
+
+def exact(ctx):
+    return 1.0 if ctx.output == ctx.expected else 0.0
+
+
+try:
+    evaluate(name="r", data=ds, task=task, scorers=[exact])
+except RuntimeError as e:
+    assert "reports to the TraceRoot platform" in str(e), str(e)
+    print("CLOUD_ONLY_RAISED")
+else:
+    raise AssertionError("expected evaluate() to raise without credentials")
+"""
+
+
+def test_evaluate_without_credentials_raises():
+    # Inherit the real env (so the venv resolves) but strip any TRACEROOT_* creds.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("TRACEROOT_")}
+    proc = subprocess.run([sys.executable, "-c", _SCRIPT], capture_output=True, text=True, env=env)
+    assert proc.returncode == 0, proc.stderr
+    assert "CLOUD_ONLY_RAISED" in proc.stdout

--- a/traceroot/eval/provenance.py
+++ b/traceroot/eval/provenance.py
@@ -19,6 +19,7 @@ Shape:
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from typing import Any
 
@@ -44,11 +45,14 @@ def _resolved_git(env: dict[str, str]) -> tuple[str | None, str | None]:
     )
 
     client = get_client()
-    repo = getattr(client, "git_repo", None) if client is not None else None
-    ref = getattr(client, "git_ref", None) if client is not None else None
+    client_repo = getattr(client, "git_repo", None) if client is not None else None
+    client_ref = getattr(client, "git_ref", None) if client is not None else None
 
-    repo = repo or env.get(TRACEROOT_GIT_REPO) or None
-    ref = ref or env.get(TRACEROOT_GIT_REF) or None
+    # An explicitly supplied env var wins over the client-resolved value: the client resolved ITS
+    # value from os.environ at init, so when `env` IS os.environ the two agree, but when a caller
+    # passes a custom `env` mapping to control provenance, that mapping must take effect.
+    repo = env.get(TRACEROOT_GIT_REPO) or client_repo or None
+    ref = env.get(TRACEROOT_GIT_REF) or client_ref or None
     if repo is None or ref is None:
         # These helpers never raise and never warn (the warning lives in client init).
         for src in (
@@ -81,14 +85,17 @@ def _git_dirty() -> bool | None:
 
 
 def _git_block(env: dict[str, str], *, detect_dirty: bool) -> dict[str, Any] | None:
-    repo, commit = _resolved_git(env)
+    repo, ref = _resolved_git(env)
     block: dict[str, Any] = {}
     if repo:
         block["repository"] = repo
-    if commit:
-        # The SDK resolves git_ref to the commit SHA; expose it as both ref and commit.
-        block["ref"] = commit
-        block["commit"] = commit
+    if ref:
+        # git_ref may be a branch/tag, not a commit SHA. Always expose it as `ref`, but only
+        # populate `commit` when it actually looks like a SHA, so we never report a branch name
+        # as a commit.
+        block["ref"] = ref
+        if re.fullmatch(r"[0-9a-fA-F]{7,40}", ref):
+            block["commit"] = ref
     if detect_dirty:
         dirty = _git_dirty()
         if dirty is not None:

--- a/traceroot/eval/provenance.py
+++ b/traceroot/eval/provenance.py
@@ -36,7 +36,7 @@ _CI_PROVIDERS = (
 def _resolved_git(env: dict[str, str]) -> tuple[str | None, str | None]:
     """(repository, commit) using the SAME precedence the client uses, preferring the
     value already resolved on the client so no extra git warning is emitted."""
-    from traceroot import get_client
+    import traceroot
     from traceroot.env import TRACEROOT_GIT_REF, TRACEROOT_GIT_REPO
     from traceroot.git_context import (
         auto_detect_git_context,
@@ -44,7 +44,10 @@ def _resolved_git(env: dict[str, str]) -> tuple[str | None, str | None]:
         harvest_ci_git_context,
     )
 
-    client = get_client()
+    # Read an ALREADY-created client directly — never get_client(), which would lazily construct the
+    # global client (extra git probes/warnings, and telemetry init under ambient credentials). This
+    # helper must stay side-effect-free and cheap.
+    client = getattr(traceroot, "_client", None)
     client_repo = getattr(client, "git_repo", None) if client is not None else None
     client_ref = getattr(client, "git_ref", None) if client is not None else None
 
@@ -94,7 +97,9 @@ def _git_block(env: dict[str, str], *, detect_dirty: bool) -> dict[str, Any] | N
         # populate `commit` when it actually looks like a SHA, so we never report a branch name
         # as a commit.
         block["ref"] = ref
-        if re.fullmatch(r"[0-9a-fA-F]{7,64}", ref):  # SHA-1 (40) and SHA-256 (64) OIDs
+        # Only EXACT OID lengths are commits (SHA-1 = 40, SHA-256 = 64). A shorter hex-looking
+        # branch/tag (e.g. "deadbeef") must stay a ref, not be reported as a commit.
+        if re.fullmatch(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}", ref):
             block["commit"] = ref
     if detect_dirty:
         dirty = _git_dirty()

--- a/traceroot/eval/provenance.py
+++ b/traceroot/eval/provenance.py
@@ -1,0 +1,132 @@
+"""Run metadata + provenance collection for offline evaluation (Phase 4).
+
+Merges caller-supplied run metadata with automatically discovered provenance -- git
+(repository/ref/commit/dirty) and CI (provider/build_id) -- when it is available. Reuses
+the SDK's existing git-context resolution (and the value it already resolved on the client,
+so no extra git warning is printed) and degrades gracefully everywhere: detached HEAD,
+dirty trees, no remote, packaged deployments, and CI all just yield partial-or-empty
+provenance rather than failing the evaluation. No secrets or arbitrary env vars are
+captured.
+
+Shape:
+    {
+      ...user metadata (wins on key conflicts)...,
+      "git": {"repository"?, "ref"?, "commit"?, "dirty"?},
+      "ci":  {"provider", "build_id"?},
+    }
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Any
+
+# (env flag that marks the provider, provider name, env var holding the build/run id)
+_CI_PROVIDERS = (
+    ("GITHUB_ACTIONS", "github", "GITHUB_RUN_ID"),
+    ("GITLAB_CI", "gitlab", "CI_PIPELINE_ID"),
+    ("CIRCLECI", "circleci", "CIRCLE_BUILD_NUM"),
+    ("BUILDKITE", "buildkite", "BUILDKITE_BUILD_ID"),
+    ("JENKINS_URL", "jenkins", "BUILD_NUMBER"),
+)
+
+
+def _resolved_git(env: dict[str, str]) -> tuple[str | None, str | None]:
+    """(repository, commit) using the SAME precedence the client uses, preferring the
+    value already resolved on the client so no extra git warning is emitted."""
+    from traceroot import get_client
+    from traceroot.env import TRACEROOT_GIT_REF, TRACEROOT_GIT_REPO
+    from traceroot.git_context import (
+        auto_detect_git_context,
+        git_context_from_files,
+        harvest_ci_git_context,
+    )
+
+    client = get_client()
+    repo = getattr(client, "git_repo", None) if client is not None else None
+    ref = getattr(client, "git_ref", None) if client is not None else None
+
+    repo = repo or env.get(TRACEROOT_GIT_REPO) or None
+    ref = ref or env.get(TRACEROOT_GIT_REF) or None
+    if repo is None or ref is None:
+        # These helpers never raise and never warn (the warning lives in client init).
+        for src in (
+            harvest_ci_git_context(env),
+            git_context_from_files(),
+            auto_detect_git_context(),
+        ):
+            repo = repo or src.get("git_repo")
+            ref = ref or src.get("git_ref")
+            if repo and ref:
+                break
+    return repo, ref
+
+
+def _git_dirty() -> bool | None:
+    """Best-effort working-tree cleanliness. None when it cannot be determined (no git
+    binary, not a repo, packaged deploy). Bounded; never raises."""
+    try:
+        out = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    return bool(out.stdout.strip())
+
+
+def _git_block(env: dict[str, str], *, detect_dirty: bool) -> dict[str, Any] | None:
+    repo, commit = _resolved_git(env)
+    block: dict[str, Any] = {}
+    if repo:
+        block["repository"] = repo
+    if commit:
+        # The SDK resolves git_ref to the commit SHA; expose it as both ref and commit.
+        block["ref"] = commit
+        block["commit"] = commit
+    if detect_dirty:
+        dirty = _git_dirty()
+        if dirty is not None:
+            block["dirty"] = dirty
+    return block or None
+
+
+def _ci_block(env: dict[str, str]) -> dict[str, Any] | None:
+    for flag, provider, build_var in _CI_PROVIDERS:
+        if env.get(flag):
+            block: dict[str, Any] = {"provider": provider}
+            build_id = env.get(build_var)
+            if build_id:
+                block["build_id"] = build_id
+            return block
+    if env.get("CI"):  # generic CI with no recognized provider
+        return {"provider": "ci"}
+    return None
+
+
+def collect_run_provenance(
+    user_metadata: dict[str, Any] | None = None,
+    *,
+    env: dict[str, str] | None = None,
+    detect_dirty: bool = True,
+) -> dict[str, Any] | None:
+    """Build run metadata = user metadata + auto git/ci provenance (when available).
+
+    User-supplied keys win on conflict. Returns None when there is nothing to record.
+    """
+    env = env if env is not None else dict(os.environ)
+    meta: dict[str, Any] = {}
+    git = _git_block(env, detect_dirty=detect_dirty)
+    if git:
+        meta["git"] = git
+    ci = _ci_block(env)
+    if ci:
+        meta["ci"] = ci
+    if user_metadata:
+        meta = {**meta, **user_metadata}  # user metadata takes precedence
+    return meta or None

--- a/traceroot/eval/provenance.py
+++ b/traceroot/eval/provenance.py
@@ -94,7 +94,7 @@ def _git_block(env: dict[str, str], *, detect_dirty: bool) -> dict[str, Any] | N
         # populate `commit` when it actually looks like a SHA, so we never report a branch name
         # as a commit.
         block["ref"] = ref
-        if re.fullmatch(r"[0-9a-fA-F]{7,40}", ref):
+        if re.fullmatch(r"[0-9a-fA-F]{7,64}", ref):  # SHA-1 (40) and SHA-256 (64) OIDs
             block["commit"] = ref
     if detect_dirty:
         dirty = _git_dirty()

--- a/traceroot/eval/scorers.py
+++ b/traceroot/eval/scorers.py
@@ -170,7 +170,11 @@ def describe_scorers(
         base_name = getattr(s, "__name__", None) or s.__class__.__name__
         # Honor the omitted-fields contract for direct consumers too: drop keys the scorer did not
         # declare (None) instead of exposing fabricated null schema fields.
-        desc = {k: v for k, v in scorer_metadata(s, value_type=hints.get(base_name)).items() if v is not None}
+        desc = {
+            k: v
+            for k, v in scorer_metadata(s, value_type=hints.get(base_name)).items()
+            if v is not None
+        }
         out.append(desc)
     return out
 

--- a/traceroot/eval/snippets.py
+++ b/traceroot/eval/snippets.py
@@ -18,6 +18,8 @@ intentionally no pull_run / pull_evaluation.
 
 from __future__ import annotations
 
+import json
+
 LANGUAGES = ("python", "typescript")
 
 _DATASET_ID_PLACEHOLDER = "<dataset_id>"
@@ -25,8 +27,9 @@ _VERSION_ID_PLACEHOLDER = "<dataset_version_id>"
 
 
 def _q(value: str | None, placeholder: str) -> str:
-    """A double-quoted id literal, or the placeholder token (also quoted) when unknown."""
-    return f'"{value if value is not None else placeholder}"'
+    """A safely-quoted id literal, or the placeholder when unknown. JSON-encoding escapes
+    any quotes/newlines so the snippet stays a single valid string literal."""
+    return json.dumps(value if value is not None else placeholder)
 
 
 def _check_lang(lang: str) -> None:

--- a/traceroot/eval/snippets.py
+++ b/traceroot/eval/snippets.py
@@ -1,0 +1,103 @@
+"""Canonical copy-paste starter snippets for the offline-eval SDK.
+
+The SDK owns these so any surface that shows "how to bring this local" (the UI dataset
+page, the run/evaluation page, docs) templates against the real SDK signatures instead of
+hand-writing strings that drift.
+
+Mental model (identical for datasets and runs): bringing something local always means
+pulling DATA -- a dataset at a specific version.
+
+    dataset, latest   -> pull_dataset(dataset_id)
+    dataset, pinned   -> pull_dataset_version(version_id)
+    reproduce a run   -> pull_dataset_version(run.dataset_version_id)   # same primitive
+
+A run is task + scorers + data; task and scorers live in the user's code, so a run is not
+re-runnable from an id -- the platform can only return the dataset the run used. There is
+intentionally no pull_run / pull_evaluation.
+"""
+
+from __future__ import annotations
+
+LANGUAGES = ("python", "typescript")
+
+_DATASET_ID_PLACEHOLDER = "<dataset_id>"
+_VERSION_ID_PLACEHOLDER = "<dataset_version_id>"
+
+
+def _q(value: str | None, placeholder: str) -> str:
+    """A double-quoted id literal, or the placeholder token (also quoted) when unknown."""
+    return f'"{value if value is not None else placeholder}"'
+
+
+def _check_lang(lang: str) -> None:
+    if lang not in LANGUAGES:
+        raise ValueError(f"lang must be one of {LANGUAGES}, got {lang!r}")
+
+
+def dataset_latest_snippet(dataset_id: str | None = None, *, lang: str = "python") -> str:
+    """Snippet that pulls a dataset's CURRENT published version."""
+    _check_lang(lang)
+    ds = _q(dataset_id, _DATASET_ID_PLACEHOLDER)
+    if lang == "python":
+        return (
+            "from traceroot import pull_dataset\n\n"
+            f"dataset = pull_dataset({ds})  # current published version\n"
+        )
+    return (
+        'import { pullDataset } from "traceroot";\n\n'
+        f"const dataset = await pullDataset({ds});  // current published version\n"
+    )
+
+
+def dataset_version_snippet(dataset_version_id: str | None = None, *, lang: str = "python") -> str:
+    """Snippet that pulls one EXACT immutable dataset version."""
+    _check_lang(lang)
+    vid = _q(dataset_version_id, _VERSION_ID_PLACEHOLDER)
+    if lang == "python":
+        return (
+            "from traceroot import pull_dataset_version\n\n"
+            f"dataset = pull_dataset_version({vid})  # exact immutable version\n"
+        )
+    return (
+        'import { pullDatasetVersion } from "traceroot";\n\n'
+        f"const dataset = await pullDatasetVersion({vid});  // exact immutable version\n"
+    )
+
+
+def reproduce_run_snippet(dataset_version_id: str | None = None, *, lang: str = "python") -> str:
+    """Snippet that reproduces a run: pull the exact dataset version it used, then supply
+    your own task + scorers (a run is task + scorers + data; only the data is on the
+    platform). The evaluate(...) call is commented so the user fills in their code."""
+    _check_lang(lang)
+    vid = _q(dataset_version_id, _VERSION_ID_PLACEHOLDER)
+    if lang == "python":
+        return (
+            "from traceroot import evaluate, pull_dataset_version\n\n"
+            "# Reproduce a run: pull the EXACT dataset version it scored, then supply your\n"
+            "# own task + scorers. A run is task + scorers + data; only the data lives on\n"
+            "# the platform -- you bring the code (there is no run-pull primitive).\n"
+            f"dataset = pull_dataset_version({vid})\n\n"
+            "# run = evaluate(\n"
+            '#     name="<evaluation name>",\n'
+            "#     dataset=dataset,\n"
+            "#     task=your_task,            # your candidate function\n"
+            "#     scorers=[your_scorer],     # your scorer callables\n"
+            '#     candidate_version="<label>",\n'
+            "#     # baseline=<a prior run>,  # link the comparison\n"
+            "# )\n"
+        )
+    return (
+        'import { evaluate, pullDatasetVersion } from "traceroot";\n\n'
+        "// Reproduce a run: pull the EXACT dataset version it scored, then supply your\n"
+        "// own task + scorers. A run is task + scorers + data; only the data lives on\n"
+        "// the platform -- you bring the code (there is no run-pull primitive).\n"
+        f"const dataset = await pullDatasetVersion({vid});\n\n"
+        "// const run = await evaluate({\n"
+        '//   name: "<evaluation name>",\n'
+        "//   dataset,\n"
+        "//   task: yourTask,            // your candidate function\n"
+        "//   scorers: [yourScorer],     // your scorer callables\n"
+        '//   candidateVersion: "<label>",\n'
+        "//   // baseline: priorRun,     // link the comparison\n"
+        "// });\n"
+    )

--- a/traceroot/eval/snippets.py
+++ b/traceroot/eval/snippets.py
@@ -83,7 +83,6 @@ def reproduce_run_snippet(dataset_version_id: str | None = None, *, lang: str = 
             "#     task=your_task,            # your candidate function\n"
             "#     scorers=[your_scorer],     # your scorer callables\n"
             '#     candidate_version="<label>",\n'
-            "#     # baseline=<a prior run>,  # link the comparison\n"
             "# )\n"
         )
     return (
@@ -98,6 +97,5 @@ def reproduce_run_snippet(dataset_version_id: str | None = None, *, lang: str = 
         "//   task: yourTask,            // your candidate function\n"
         "//   scorers: [yourScorer],     // your scorer callables\n"
         '//   candidateVersion: "<label>",\n'
-        "//   // baseline: priorRun,     // link the comparison\n"
         "// });\n"
     )

--- a/traceroot/eval/types.py
+++ b/traceroot/eval/types.py
@@ -290,7 +290,13 @@ class Dataset:
             header = records[0]
             d = {
                 k: header.get(k)
-                for k in ("dataset_id", "name", "description", "base_version_id", "dataset_version_id")
+                for k in (
+                    "dataset_id",
+                    "name",
+                    "description",
+                    "base_version_id",
+                    "dataset_version_id",
+                )
             }
             d["cases"] = [{k: v for k, v in rec.items() if k != "type"} for rec in records[1:]]
             return cls.from_dict(d)


### PR DESCRIPTION
## Summary

Adds the local-only pieces that let a run be fully identified before any network round trip: run-provenance collection (git + CI), copy-paste snippet helpers for the common flows, and client-side id minting. Ids are minted with typed, prefixed, time-sortable identifiers so a run has a stable identity before it is registered, and provenance is machine-independent and captures no secrets.

Fixes: traceroot-ai/traceroot#1682

## How it works

Provenance merges auto-discovered git context (repository/ref/commit, plus an optional dirty flag) and CI context (provider + build id) with user-supplied metadata, where the user's keys win on conflict. The default path is cheap and reuses the SDK's already-resolved git context without spawning `git status`; an explicit dirty-check helper runs the subprocess only when a caller asks for it. Ids are ULIDs (48-bit millisecond timestamp + 80 random bits, Crockford base32) carrying typed prefixes — `ds_`, `tc_`, `run_`. Snippet helpers template against the real SDK signatures so any surface that shows "how to bring this local" stays in sync, emitting placeholders when ids are absent.

## What's included

### Source
- `traceroot/eval/ids.py` — stdlib ULID (`ulid`) and typed minters `new_dataset_id`/`new_test_case_id`/`new_run_id`.
- `traceroot/eval/provenance.py` — `collect_run_provenance` (git + CI + user metadata merge, user wins), a cheap default path plus an explicit `_git_dirty` check; degrades gracefully on detached HEAD, no remote, and packaged deploys.
- `traceroot/eval/snippets.py` — `dataset_latest_snippet`, `dataset_version_snippet`, and `reproduce_run_snippet`, rendering current call signatures (Python or TypeScript) with placeholders for absent ids; a run is reproduced by pulling its `dataset_version_id`, so there is intentionally no run-pull snippet.

### Tests
- `tests/eval/test_ids.py` — ULID format, typed prefixes, uniqueness, and rough time-ordering.
- `tests/eval/test_provenance.py` — CI/git + user-metadata merge (user wins), machine-independence, and the cheap-path/dirty-check split.
- `tests/eval/test_snippets.py` — snippets emit current signatures and placeholders when ids are absent.

## Test plan

- [ ] Confirm provenance merges CI/git context with user metadata (user wins on conflict) and is machine-independent.
- [ ] Confirm the cheap path collects provenance without a `git status` call, and the dirty flag is available on request.
- [ ] Confirm snippet helpers emit current call signatures, and placeholders when ids are absent.
- [ ] Confirm minted ids are unique, typed/prefixed, and roughly time-sortable.
