### PR TITLE
feat(eval): progressive scorer API + SDK-resolved per-score passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,122 @@
 
 Please see the [Python SDK Docs](https://traceroot.ai/docs/tracing/get-started) for details.
 
+# Offline Evaluation
+
+Run your AI app over a dataset, score each case with your own scorers, and report the results to
+TraceRoot to compare candidates over time. A runnable end-to-end example lives in
+[`examples/offline_eval.py`](examples/offline_eval.py) (it needs no backend — see below).
+
+## Quickstart (5 minutes)
+
+```python
+import traceroot
+from traceroot import Dataset, ScorerContext, evaluate
+from traceroot.eval import scorer
+
+# 1. A dataset — cases with an input and an optional expected reference.
+dataset = Dataset("support-routing")
+dataset.add(input={"message": "I was charged twice"}, expected={"route": "billing"})
+dataset.add(input={"message": "the app keeps crashing"}, expected={"route": "technical"})
+
+# 2. Your app (the "task"): one case input -> one candidate output.
+def route_ticket(ticket: dict) -> dict:
+    msg = ticket["message"].lower()
+    return {"route": "billing" if "charge" in msg else "technical" if "crash" in msg else "general"}
+
+# 3. A scorer. @scorer declares the metric's comparison policy; it receives a ScorerContext
+#    (input / output / expected / metadata) and returns a value, bool, Score, or list of Scores.
+@scorer(value_type="numeric", direction="higher_is_better", threshold=1.0)
+def accuracy(ctx: ScorerContext) -> float:
+    return 1.0 if ctx.output["route"] == ctx.expected["route"] else 0.0
+
+# 4. Run it. `evaluate` pulls its cases from a synced dataset and reports to the platform.
+run = evaluate(name="routing-v1", dataset=dataset, task=route_ticket, scorers=[accuracy])
+print(run.summary())
+```
+
+## Datasets: create, publish, pull, version
+
+```python
+ds = Dataset("support-routing")                     # create
+ds.upsert(input={"message": "hi"}, id="c1", expected={"route": "general"})
+ds.push()                                            # publish to the platform (creates a version)
+
+pulled = traceroot.pull_dataset("<dataset-id>")      # pull the current version (needs credentials)
+exact  = traceroot.pull_dataset("<dataset-id>", version_id="<version-id>")   # pull a pinned version
+ds.push(base_version_id="<version-id>")              # publish a NEW version based on an existing one
+```
+
+Pulling a dataset stamps its `dataset_id`/`dataset_version_id` onto the returned `Dataset`, so a run
+against it is pinned to the exact cases it scored (reproducible).
+
+## Scorers
+
+A **deterministic** scorer is any function of the `ScorerContext`. `@scorer` declares its metric
+policy; the emitted `Score` name may differ from the function name (a `grade` function may emit a
+`quality` metric):
+
+```python
+from traceroot import Score
+
+@scorer(value_type="numeric", direction="lower_is_better", threshold=0.2)
+def grade(ctx: ScorerContext) -> Score:
+    return Score("quality", latency_seconds(ctx.output))   # emits the metric "quality"
+```
+
+An **LLM judge** — `model` + `messages` are its reported definition; `{{output}}` etc. interpolate
+the case. Provide `complete=...` to stub the model (deterministic/offline), or omit it to call the
+real model:
+
+```python
+from traceroot.eval import llm_judge
+
+tone = llm_judge(
+    name="tone", model="claude-sonnet-5",
+    messages=[{"role": "user", "content": "Rate politeness 0..1:\n{{output}}"}],
+    output_type="score",
+)
+```
+
+## Main score, threshold, direction
+
+- Each scorer declares its own **`threshold`** and **`direction`** (`higher_is_better` /
+  `lower_is_better`); that policy decides whether the metric passes for a case.
+- The **main score** is the headline metric that sets each case's pass/fail. With a **single**
+  scorer it is inferred from the one metric emitted — you don't name it, even if the function name
+  differs from the emitted metric name. With **multiple** numeric metrics, name it explicitly:
+  `evaluate(..., main_score="accuracy")`; otherwise the run fails loudly rather than guess.
+
+## Reporting, transports, and failure behavior
+
+`evaluate` is cloud-first: it reports to TraceRoot using `TRACEROOT_API_KEY` and a synced dataset.
+The **default transport** is built for you from those. Pass an **explicit transport** to control
+reporting directly — both behave identically for scoring:
+
+```python
+from traceroot.eval.platform import PlatformTransport
+t = PlatformTransport("<dataset-id>", candidate_version="v2")
+run = evaluate(name="routing-v2", dataset=pulled, task=route_ticket, scorers=[accuracy], transport=t)
+```
+
+Honest statuses, never faked: a **task** error → `errored`; a **scorer** error is isolated to that
+scorer (other scorers on the case still record); a case with no numeric/boolean score →
+`not_scored` (never a silent 0).
+
+## Candidate vs. baseline
+
+Tag each run with `candidate_version` (e.g. `"v1"`, `"gpt-4o"`); the SDK reports only the candidate
+and never a baseline linkage — **comparison is done in the TraceRoot UI**, where you pick the
+baseline run to diff against. Re-run the same dataset with a new `candidate_version` to compare:
+
+```python
+evaluate(name="routing", dataset=pulled, task=route_ticket, scorers=[accuracy], candidate_version="v1")
+evaluate(name="routing", dataset=pulled, task=route_v2,     scorers=[accuracy], candidate_version="v2")
+```
+
+See the [platform evaluation docs](https://traceroot.ai/docs) for the UI: run tables, comparison,
+and the scorer catalog.
+
 <!-- Links -->
 
 [discord-image]: https://img.shields.io/discord/1395844148568920114?logo=discord&labelColor=%235462eb&logoColor=%23f5f5f5&color=%235462eb

--- a/README.md
+++ b/README.md
@@ -14,18 +14,25 @@ Please see the [Python SDK Docs](https://traceroot.ai/docs/tracing/get-started) 
 
 # Offline Evaluation
 
-Run your AI app over a dataset, score each case with your own scorers, and report the results to
-TraceRoot to compare candidates over time. A runnable end-to-end example lives in
-[`examples/offline_eval.py`](examples/offline_eval.py) (it needs no backend — see below).
+Run your AI app over a dataset, score each case with your own scorers, and (optionally) report the
+results to TraceRoot to compare candidates over time. A runnable end-to-end example lives in
+[`examples/offline_eval.py`](examples/offline_eval.py) — it runs offline via an in-memory transport.
 
-## Quickstart (5 minutes)
+`evaluate()` is **cloud-first**: by default it reports to TraceRoot and therefore needs
+`TRACEROOT_API_KEY` and a **pulled** dataset (a purely local `Dataset` cannot start a reported run).
+For a self-contained run with no backend, pass an in-memory transport (below).
+
+The task, scorer, and reporting behavior are identical in both modes — only the dataset source and
+the transport differ.
+
+## Quickstart — local run (no backend)
 
 ```python
-import traceroot
 from traceroot import Dataset, ScorerContext, evaluate
 from traceroot.eval import scorer
+from traceroot.eval.transport import FakeTransport  # in-memory stand-in for the platform
 
-# 1. A dataset — cases with an input and an optional expected reference.
+# 1. A local dataset — add(input, *, expected=..., id=...). (No cloud dataset is created.)
 dataset = Dataset("support-routing")
 dataset.add(input={"message": "I was charged twice"}, expected={"route": "billing"})
 dataset.add(input={"message": "the app keeps crashing"}, expected={"route": "technical"})
@@ -41,21 +48,58 @@ def route_ticket(ticket: dict) -> dict:
 def accuracy(ctx: ScorerContext) -> float:
     return 1.0 if ctx.output["route"] == ctx.expected["route"] else 0.0
 
-# 4. Run it. `evaluate` pulls its cases from a synced dataset and reports to the platform.
-run = evaluate(name="routing-v1", dataset=dataset, task=route_ticket, scorers=[accuracy])
+# 4. Run it locally — FakeTransport keeps everything in-memory (nothing is uploaded).
+run = evaluate(name="routing-v1", dataset=dataset, task=route_ticket, scorers=[accuracy],
+               transport=FakeTransport())
 print(run.summary())
 ```
 
-## Datasets: create, publish, pull, version
+## Quickstart — cloud run (reports to TraceRoot)
+
+Create the dataset in the **TraceRoot UI**, then pull it and run — the run appears in the platform.
 
 ```python
-ds = Dataset("support-routing")                     # create
-ds.upsert(input={"message": "hi"}, id="c1", expected={"route": "general"})
-ds.push()                                            # publish to the platform (creates a version)
+import traceroot
+from traceroot import ScorerContext, evaluate
+from traceroot.eval import scorer
 
-pulled = traceroot.pull_dataset("<dataset-id>")      # pull the current version (needs credentials)
-exact  = traceroot.pull_dataset("<dataset-id>", version_id="<version-id>")   # pull a pinned version
-ds.push(base_version_id="<version-id>")              # publish a NEW version based on an existing one
+# Needs TRACEROOT_API_KEY. Pull the dataset you created in the UI (this is the synced dataset a
+# reported run requires); it arrives with its dataset_id/dataset_version_id already set.
+dataset = traceroot.pull_dataset("<dataset-id>")
+
+@scorer(value_type="numeric", direction="higher_is_better", threshold=1.0)
+def accuracy(ctx: ScorerContext) -> float:
+    return 1.0 if ctx.output["route"] == ctx.expected["route"] else 0.0
+
+def route_ticket(ticket: dict) -> dict:
+    msg = ticket["message"].lower()
+    return {"route": "billing" if "charge" in msg else "technical" if "crash" in msg else "general"}
+
+run = evaluate(name="routing-v1", dataset=dataset, task=route_ticket, scorers=[accuracy],
+               candidate_version="v1")           # -> a real run visible in the TraceRoot UI
+print(run.upload.dashboard_url)                    # link to the run in the platform
+```
+
+## Datasets
+
+Cases are added locally with `add(input, *, expected=..., id=...)` or `upsert(EvalCase(...))`:
+
+```python
+from traceroot import Dataset, EvalCase
+
+ds = Dataset("support-routing")
+ds.add(input={"message": "hi"}, id="c1", expected={"route": "general"})
+ds.upsert(EvalCase(input={"message": "bye"}, id="c2", expected={"route": "general"}))
+```
+
+**Datasets are created and versioned in the TraceRoot UI, not from the SDK.** `ds.push()` returns
+`status="local_only"` and does **not** create a platform dataset. To run a reported evaluation, create
+the dataset in the UI and pull it:
+
+```python
+import traceroot
+pulled = traceroot.pull_dataset("<dataset-id>")                              # current version
+exact  = traceroot.pull_dataset("<dataset-id>", version_id="<version-id>")   # a pinned version
 ```
 
 Pulling a dataset stamps its `dataset_id`/`dataset_version_id` onto the returned `Dataset`, so a run

--- a/examples/offline_eval.py
+++ b/examples/offline_eval.py
@@ -1,0 +1,84 @@
+"""Offline Evaluation — runnable end-to-end example (Python).
+
+Evaluation is cloud-first: a real run pulls a dataset and reports results to the TraceRoot platform
+(see "Reporting to the platform" in the README):
+
+    import traceroot
+    dataset = traceroot.pull_dataset("<dataset-id>")        # needs TRACEROOT_API_KEY
+    run = evaluate(name="...", dataset=dataset, task=..., scorers=[...])
+
+So it runs fully OFFLINE against the wheel with no backend, this example passes an in-memory
+`FakeTransport` (the stand-in transport the SDK's own tests use) in place of the platform. Everything
+else — datasets, scorers, the ScorerContext, main-score resolution, the four honest statuses — is
+exactly what a reported run does.
+
+    python examples/offline_eval.py
+"""
+
+from traceroot import Dataset, Score, ScorerContext, evaluate
+from traceroot.eval import llm_judge, scorer
+from traceroot.eval.transport import FakeTransport
+
+
+# --- 1. The app under test (your "task"): input case -> candidate output --------------------
+def route_ticket(ticket: dict) -> dict:
+    msg = ticket["message"].lower()
+    if "refund" in msg or "charge" in msg:
+        return {"route": "billing"}
+    if "crash" in msg or "error" in msg:
+        return {"route": "technical"}
+    return {"route": "general"}
+
+
+# --- 2. A dataset: cases with input + (optional) expected reference --------------------------
+dataset = Dataset("support-routing")
+dataset.add(input={"message": "I was charged twice"}, expected={"route": "billing"})
+dataset.add(input={"message": "the app keeps crashing"}, expected={"route": "technical"})
+dataset.add(input={"message": "hello there"}, expected={"route": "general"})
+
+
+# --- 3. Scorers ------------------------------------------------------------------------------
+# A deterministic scorer. `@scorer` declares the metric's policy: how its value is compared
+# (direction) and the pass threshold. It receives a ScorerContext (input / output / expected /
+# metadata) and returns a value, a bool, a Score, or a list of Scores.
+@scorer(value_type="numeric", direction="higher_is_better", threshold=1.0)
+def accuracy(ctx: ScorerContext) -> float:
+    return 1.0 if ctx.output["route"] == ctx.expected["route"] else 0.0
+
+
+# A scorer may emit a metric whose NAME differs from the function name, and may attach a comment.
+@scorer(value_type="boolean")
+def is_confident(ctx: ScorerContext) -> Score:
+    return Score("confident", ctx.output["route"] != "general", comment="non-general route")
+
+
+# An LLM judge. `complete` is stubbed here so the example is deterministic and offline; drop it to
+# call the real model named by `model`. The judge is reported by its definition (model + messages).
+tone = llm_judge(
+    name="tone",
+    model="claude-sonnet-5",
+    messages=[{"role": "user", "content": "Rate politeness 0..1 for:\n{{output}}"}],
+    output_type="score",
+    complete=lambda model, messages: "0.9",  # remove to hit the real model
+)
+
+
+# --- 4. Run the evaluation ------------------------------------------------------------------
+# `main_score` names the headline metric when several numeric metrics exist; with a single scorer it
+# is inferred from the one metric it emits, so you can omit it. Swap `transport=FakeTransport()` for a
+# pulled dataset + TRACEROOT_API_KEY to report the identical run to the platform.
+run = evaluate(
+    name="support-routing-v1",
+    dataset=dataset,
+    task=route_ticket,
+    scorers=[accuracy, is_confident, tone],
+    main_score="accuracy",  # the metric that decides pass/fail per case
+    candidate_version="v1",
+    transport=FakeTransport(),  # in-memory stand-in so the example needs no backend
+)
+
+# --- 5. Inspect results ---------------------------------------------------------------------
+print(run.summary())  # a formatted report: pass/fail/errored/not_scored counts + per-metric means
+for item in run.item_results:
+    scores = ", ".join(f"{s.name}={s.value!r}" for s in item.scores)
+    print(f"  {item.case_id}: [{scores}]")

--- a/tests/eval/test_emitted_metrics.py
+++ b/tests/eval/test_emitted_metrics.py
@@ -1,0 +1,72 @@
+"""Emitted-metric ownership manifest at completion.
+
+A scorer DEFINITION (``grade``) owns the METRIC it emits (``quality``). The platform keys a metric's
+policy on the EMITTED-metric name, so completion must carry ``scorers[].emitted_metrics`` recording
+that ``grade`` emits ``quality`` with grade's declared policy -- otherwise the platform cannot resolve
+``quality``'s threshold/direction and defaults it (wrong pass/fail and comparison verdicts).
+"""
+
+from traceroot.eval import Dataset, EvalCase, Score, evaluate, scorer
+from traceroot.eval.platform import PlatformTransport
+
+
+class _Capture(PlatformTransport):
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        self.requests: list[tuple] = []
+
+    def _request(self, method, path, body=None):
+        self.requests.append((method, path, body))
+        if path.endswith("/evaluation-runs"):
+            return {"evaluation_run_id": "run1"}
+        return {}
+
+
+@scorer(value_type="numeric", direction="lower_is_better", threshold=0.62)
+def grade(ctx):
+    return Score("quality", 0.3)  # emitted metric 'quality' != definition name 'grade'
+
+
+@scorer(value_type="numeric", direction="higher_is_better", threshold=0.0)
+def length(ctx):
+    return Score("length", 1.0)
+
+
+def _ds():
+    ds = Dataset("d")
+    ds.dataset_id = "ds_1"
+    ds.dataset_version_id = "v1"
+    ds.upsert(EvalCase(input="i", id="c0", expected="e"))
+    return ds
+
+
+def _complete(requests):
+    return next(b for _m, p, b in requests if p.endswith("/complete"))
+
+
+def test_completion_carries_emitted_metric_ownership():
+    t = _Capture("ds_1", api_key="tr-x", host_url="https://h", dataset_version_id="v1")
+    evaluate(name="r", dataset=_ds(), task=lambda x: "out", scorers=[grade, length],
+             main_score="quality", report_to=t)
+    by = {s["name"]: s for s in _complete(t.requests)["scorers"]}
+    # Definition 'grade' declares it emits metric 'quality' with grade's OWN policy -- the platform
+    # can now key quality's threshold/direction on the emitted name, not the definition name.
+    assert by["grade"]["emitted_metrics"] == [
+        {"name": "quality", "value_type": "numeric", "direction": "lower_is_better", "threshold": 0.62}
+    ]
+    # Function identity stays separate from metric identity.
+    assert by["grade"]["name"] == "grade"
+    assert by["length"]["emitted_metrics"] == [
+        {"name": "length", "value_type": "numeric", "direction": "higher_is_better", "threshold": 0.0}
+    ]
+
+
+def test_single_scorer_name_divergent_metric_manifest():
+    """One scorer, emitted name != function name, no explicit main -> the manifest still records
+    grade->quality so the platform resolves the sole metric's policy."""
+    t = _Capture("ds_1", api_key="tr-x", host_url="https://h", dataset_version_id="v1")
+    evaluate(name="r", dataset=_ds(), task=lambda x: "out", scorers=[grade], report_to=t)
+    by = {s["name"]: s for s in _complete(t.requests)["scorers"]}
+    assert by["grade"]["emitted_metrics"] == [
+        {"name": "quality", "value_type": "numeric", "direction": "lower_is_better", "threshold": 0.62}
+    ]

--- a/tests/eval/test_platform.py
+++ b/tests/eval/test_platform.py
@@ -187,6 +187,36 @@ class TestPlatformTransport:
             "string_value": "billing",
         } in body["scores"]
 
+    def test_explicit_transport_resolves_single_scorer_after_specs_injected(self):
+        """Regression: an explicitly-constructed transport (no scorer_names at __init__) whose
+        scorer_specs are injected AFTER construction — exactly what the engine does — must still
+        resolve the single scorer's emitted metric name-agnostically. Freezing the name-agnostic
+        flag from the empty constructor makes every case report not_scored / null main. A fn named
+        'grade' emitting Score(name='quality') under lower_is_better must SCORE the case."""
+        from traceroot.eval.results import EvalItemResult
+
+        t = RecordingTransport("ds_1", api_key="tr-x", host_url="https://h")  # no scorer_names
+        # Engine injects specs after construction (engine._run: active_transport.scorer_specs = ...).
+        t.scorer_specs = [
+            {
+                "name": "grade",
+                "version": "v1",
+                "threshold": 0.2,
+                "direction": "lower_is_better",
+                "value_type": "numeric",
+            }
+        ]
+        t.create_run("r", "d", None)
+        item = EvalItemResult(
+            "tc0", "i", "o", "e",
+            [Score("quality", 0.3)],  # emitted 'quality' != fn 'grade'; 0.3 > 0.2 (lower better) -> fail
+            {}, None, "t",
+        )
+        t.record_item_result(None, item)
+        body = t.requests[-1][2]
+        assert body["status"] == "failed"
+        assert body["main_score"] == 0.3
+
     def test_result_reports_duration_ms_as_nonneg_int(self):
         from traceroot.eval.results import EvalItemResult
 

--- a/tests/eval/test_platform.py
+++ b/tests/eval/test_platform.py
@@ -217,6 +217,57 @@ class TestPlatformTransport:
         assert body["status"] == "failed"
         assert body["main_score"] == 0.3
 
+    def test_scores_payload_includes_per_score_passed(self):
+        """Each emitted score carries an SDK-computed `passed` (contract ScoreInput.passed) so the
+        platform never re-derives policy. A single scorer 'grade' emitting Score(name='quality',
+        value=0.3) under lower_is_better threshold 0.2 -> 0.3 <= 0.2 is False -> passed False,
+        consistent with the case status 'failed'. The emitted name stays the score identity."""
+        from traceroot.eval.results import EvalItemResult
+
+        t = RecordingTransport("ds_1", api_key="tr-x", host_url="https://h")
+        t.scorer_specs = [
+            {"name": "grade", "version": "v1", "threshold": 0.2,
+             "direction": "lower_is_better", "value_type": "numeric"}
+        ]
+        t.create_run("r", "d", None)
+        item = EvalItemResult("tc0", "i", "o", "e", [Score("quality", 0.3)], {}, None, "t")
+        t.record_item_result(None, item)
+        scores = t.requests[-1][2]["scores"]
+        assert scores[0]["scorer_name"] == "quality"  # emitted-metric identity, unchanged
+        assert scores[0]["passed"] is False
+
+    def test_per_score_passed_value_types_and_multi_scorer(self):
+        """passed is honest per value type and per owning policy. Boolean: true = pass. Categorical:
+        no pass/fail -> omitted. With multiple scorers each numeric score is judged by the scorer
+        whose declared name matches the emitted metric; a numeric metric that matches no declared
+        scorer is left unresolved (omitted, never guessed)."""
+        from traceroot.eval.results import EvalItemResult
+
+        t = RecordingTransport("ds_1", api_key="tr-x", host_url="https://h")
+        t.scorer_specs = [
+            {"name": "accuracy", "version": "v1", "threshold": 1.0,
+             "direction": "higher_is_better", "value_type": "numeric"},
+            {"name": "is_billing", "version": "v1", "value_type": "boolean"},
+            {"name": "route", "version": "v1", "value_type": "categorical"},
+        ]
+        t.create_run("r", "d", None)
+        item = EvalItemResult(
+            "tc0", "i", "o", "e",
+            [
+                Score("accuracy", 1.0),      # 1.0 >= 1.0 -> passed True
+                Score("is_billing", True),   # boolean true -> passed True
+                Score("route", "billing"),   # categorical -> no pass/fail -> omitted
+                Score("mystery", 0.5),        # numeric, matches no declared scorer -> omitted
+            ],
+            {}, None, "t",
+        )
+        t.record_item_result(None, item)
+        by_name = {s["scorer_name"]: s for s in t.requests[-1][2]["scores"]}
+        assert by_name["accuracy"]["passed"] is True
+        assert by_name["is_billing"]["passed"] is True
+        assert "passed" not in by_name["route"]
+        assert "passed" not in by_name["mystery"]
+
     def test_result_reports_duration_ms_as_nonneg_int(self):
         from traceroot.eval.results import EvalItemResult
 

--- a/tests/eval/test_progressive_scorers.py
+++ b/tests/eval/test_progressive_scorers.py
@@ -1,0 +1,77 @@
+"""Phase 1 — progressive scorer API: ordinary functions + simple returns.
+
+A scorer may be an ordinary function taking (input, output, expected=None, metadata=None) OR the
+existing single-ScorerContext form. Returns may be a scalar, a {name,value} object, a metric->value
+map, a Score, a Score[], or None. Everything normalizes to the same internal Score list.
+"""
+
+from traceroot.eval import Dataset, Score, evaluate
+from traceroot.eval.transport import FakeTransport
+
+
+def _ds():
+    ds = Dataset("d")
+    ds.add(input={"q": "hi"}, id="c0", expected="hi")
+    return ds
+
+
+def _run(scorers, main_score=None):
+    return evaluate(
+        name="r", dataset=_ds(), task=lambda x: "hi", scorers=scorers,
+        main_score=main_score, transport=FakeTransport(),
+    )
+
+
+def _scores(run):
+    return {s.name: s.value for s in run.item_results[0].scores}
+
+
+def test_plain_four_arg_function_scorer():
+    """An ordinary function (input, output, expected=None, metadata=None) works as a scorer."""
+    def accuracy(input, output, expected=None, metadata=None):
+        return 1.0 if output == expected else 0.0
+
+    assert _scores(_run([accuracy])) == {"accuracy": 1.0}
+
+
+def test_plain_two_arg_function_scorer():
+    def exact(input, output):
+        return output == input["q"]
+
+    # output "hi" == input["q"] "hi" -> True
+    assert _scores(_run([exact])) == {"exact": True}
+
+
+def test_backward_compatible_single_ctx_scorer():
+    """The existing single-ScorerContext form still works (arity 1 == ctx)."""
+    def by_ctx(ctx):
+        return 1.0 if ctx.output == ctx.expected else 0.0
+
+    assert _scores(_run([by_ctx])) == {"by_ctx": 1.0}
+
+
+def test_metric_map_return():
+    """A dict with no 'name' key is a metric->value map yielding one Score per entry."""
+    def multi(input, output):
+        return {"len_ok": len(output) > 0, "starts_h": output.startswith("h")}
+
+    assert _scores(_run([multi], main_score="len_ok")) == {"len_ok": True, "starts_h": True}
+
+
+def test_named_object_return_still_single_score():
+    """A dict WITH a 'name' key stays a single named Score (unchanged)."""
+    def one(input, output):
+        return {"name": "quality", "value": 0.7}
+
+    assert _scores(_run([one])) == {"quality": 0.7}
+
+
+def test_unsupported_signature_raises_actionable_error():
+    def weird(a, b, c, d, e):
+        return 1.0
+
+    try:
+        _run([weird])
+        raise AssertionError("expected an error for an unsupported scorer signature")
+    except (TypeError, ValueError) as e:
+        assert "signature" in str(e).lower() or "positional" in str(e).lower()

--- a/tests/eval/test_reporting_ownership.py
+++ b/tests/eval/test_reporting_ownership.py
@@ -100,8 +100,9 @@ class TestSendsRawData:
         assert "duration_ms" in ok  # measurement present (int or null)
         assert "trace_id" in ok  # trace identity link
         assert ok["scores"] == [
-            {"scorer_name": "acc", "scorer_version": "v2", "numeric_value": 1.0}
-        ]  # raw per-scorer value + declared version
+            {"scorer_name": "acc", "scorer_version": "v2", "numeric_value": 1.0, "passed": True}
+        ]  # raw per-scorer value + declared version + SDK-computed pass/fail (its OWN policy,
+        # not a comparison against a baseline -- see TestDoesNotSendComparisonLabels)
 
         # scorer error: preserved as a per-scorer error, task_error stays null
         se = by_id["c1"]

--- a/traceroot/eval/engine.py
+++ b/traceroot/eval/engine.py
@@ -241,6 +241,7 @@ async def _run_case(
     on_case_start: Callable[[EvalCase], None] | None = None,
     on_case_complete: Callable[[EvalItemResult, float], None] | None = None,
     executor: ThreadPoolExecutor | None = None,
+    emitted_ownership: dict[str, set[str]] | None = None,
 ) -> EvalItemResult:
     tracer = _eval_tracer()
     async with semaphore:
@@ -312,6 +313,11 @@ async def _run_case(
                 )
                 for scorer in scorers:
                     name = getattr(scorer, "__name__", scorer.__class__.__name__)
+                    # Record scorer->metric ownership AT THE POINT OF PRODUCTION (never inferred
+                    # afterward by matching names). Seed the definition now so a scorer that errors
+                    # before emitting still appears in the completion manifest with no metrics.
+                    if emitted_ownership is not None:
+                        emitted_ownership.setdefault(name, set())
                     with tracer.start_as_current_span(name) as scorer_span:
                         scorer_span.set_attribute(SpanAttributes.SPAN_TYPE, SpanKind.SCORER)
                         scorer_span.set_attribute(SpanAttributes.EVAL_RUN_NAME, identity.name)
@@ -333,6 +339,10 @@ async def _run_case(
                                 _normalize_score_like(raw, name), scorer
                             )
                             scores.extend(produced)
+                            if emitted_ownership is not None:
+                                emitted_ownership[name].update(
+                                    s.name for s in produced if s.name
+                                )
                             _record_scorer_span(scorer_span, produced)
                             if produced:  # span.output = the score value(s) + explanation
                                 set_span_attribute(
@@ -613,6 +623,9 @@ async def _run_async(
     summary: dict[str, Any] = {}
     resolved_main: str | None = None
     resolve_error: MainScoreError | None = None
+    # definition name -> the metric names it emitted, accumulated across cases (union: a metric
+    # emitted by only some cases still counts). Recorded during execution, sent at completion.
+    emitted_ownership: dict[str, set[str]] = {}
     try:
         item_results = await asyncio.gather(
             *[
@@ -628,6 +641,7 @@ async def _run_async(
                     on_case_start=case_start_hook,
                     on_case_complete=case_complete_hook,
                     executor=sync_executor,
+                    emitted_ownership=emitted_ownership,
                 )
                 for c in cases
             ]
@@ -653,6 +667,7 @@ async def _run_async(
             run_handle,
             status="failed" if resolve_error is not None else None,
             main_score_name=resolved_main,
+            emitted_metrics={k: sorted(v) for k, v in emitted_ownership.items()},
         )
 
     if resolve_error is not None:

--- a/traceroot/eval/engine.py
+++ b/traceroot/eval/engine.py
@@ -103,12 +103,27 @@ def _normalize_score_like(raw: Any, default_name: str) -> list[Score]:
                 )
         return list(raw)
     if isinstance(raw, dict):
-        if "name" not in raw or "value" not in raw:
-            raise ValueError("scorer dict result must contain 'name' and 'value'")
-        unknown = set(raw) - {"name", "value", "comment", "metadata"}
-        if unknown:
-            raise ValueError(f"scorer dict result has unknown key(s): {sorted(unknown)}")
-        return [Score(**raw)]
+        if "name" in raw or "value" in raw:
+            # Single named Score: {"name", "value", comment?, metadata?}. Presence of EITHER reserved
+            # key means the single-Score shape is intended, so both are required (a {"value": ...}
+            # without a name stays an error, not a metric named "value").
+            if "name" not in raw or "value" not in raw:
+                raise ValueError("scorer dict result must contain 'name' and 'value'")
+            unknown = set(raw) - {"name", "value", "comment", "metadata"}
+            if unknown:
+                raise ValueError(f"scorer dict result has unknown key(s): {sorted(unknown)}")
+            return [Score(**raw)]
+        # Neither 'name' nor 'value' -> a metric->value mapping; one Score per entry, keyed by the
+        # metric name. (A metric literally named "name"/"value" must use the single-Score form.)
+        scores: list[Score] = []
+        for k, v in raw.items():
+            if not isinstance(v, (bool, int, float, str)):
+                raise TypeError(
+                    f"metric-map value for {k!r} must be a scalar (bool/int/float/str), "
+                    f"got {type(v).__name__}"
+                )
+            scores.append(Score(name=str(k), value=v))
+        return scores
     # bool is a subclass of int; str is categorical - all valid scalars.
     if isinstance(raw, (bool, int, float, str)):
         return [Score(name=default_name, value=raw)]
@@ -132,9 +147,12 @@ def _sync_executor(max_workers: int) -> ThreadPoolExecutor:
 
 
 async def _await_or_run(
-    fn: Callable[[Any], Any], arg: Any, executor: ThreadPoolExecutor | None = None
+    fn: Callable[..., Any],
+    args: tuple,
+    kwargs: dict | None = None,
+    executor: ThreadPoolExecutor | None = None,
 ) -> Any:
-    """Call fn(arg) whether it is sync or async.
+    """Call fn(*args, **kwargs) whether it is sync or async.
 
     Coroutine functions — and callable *instances* whose ``__call__`` is async — are awaited on
     the loop. Plain sync callables run in ``executor`` (a bounded per-run thread pool) so that a
@@ -143,17 +161,81 @@ async def _await_or_run(
     is copied into the worker so the OTel span active at the call site still parents any spans the
     sync callable creates.
     """
+    kwargs = kwargs or {}
     if inspect.iscoroutinefunction(fn):
-        return await fn(arg)
+        return await fn(*args, **kwargs)
     loop = asyncio.get_running_loop()
     ctx = contextvars.copy_context()
-    result = await loop.run_in_executor(executor, lambda: ctx.run(fn, arg))
+    result = await loop.run_in_executor(executor, lambda: ctx.run(fn, *args, **kwargs))
     # A callable *instance* whose __call__ is async is NOT a coroutine function, so it ran in the
     # thread and returned an un-awaited coroutine; await it on the loop so the coroutine is never
     # surfaced as the task/scorer output.
     if inspect.isawaitable(result):
         result = await result
     return result
+
+
+_PLAIN_FIELDS = ("input", "output", "expected", "metadata")
+
+
+def _scorer_target(scorer: Any) -> Any:
+    if inspect.isfunction(scorer) or inspect.ismethod(scorer) or inspect.isbuiltin(scorer):
+        return scorer
+    return getattr(scorer, "__call__", scorer)
+
+
+def _scorer_call_plan(scorer: Any) -> tuple[str, tuple[str, ...]]:
+    """Decide how to invoke a scorer, by PARAMETER NAME (never by bare arity, so a closure default
+    like ``def fn(ctx, _cfg=X)`` is not mistaken for a two-arg plain scorer):
+
+      - a parameter named ``input`` or ``output`` -> PLAIN form; called by keyword with the declared
+        subset of (input, output, expected, metadata);
+      - otherwise -> the ScorerContext form ``scorer(ctx)`` (any extra parameters keep their defaults).
+
+    Returns ``("plain", fields)`` or ``("ctx", ())``. Raises an actionable error for a signature that
+    fits neither (e.g. a plain scorer with an undeclared required parameter, or a ctx scorer that
+    requires more than the single context argument). Un-introspectable callables default to ctx."""
+    try:
+        params = list(inspect.signature(_scorer_target(scorer)).parameters.values())
+    except (ValueError, TypeError):
+        return ("ctx", ())
+    pos = [p for p in params if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)]
+    names = [p.name for p in pos]
+    has_kwargs = any(p.kind == p.VAR_KEYWORD for p in params)
+    has_varargs = any(p.kind == p.VAR_POSITIONAL for p in params)
+    label = getattr(scorer, "__name__", type(scorer).__name__)
+    if "input" in names or "output" in names:
+        unsupported = [p.name for p in pos if p.default is p.empty and p.name not in _PLAIN_FIELDS]
+        if unsupported and not has_kwargs:
+            raise TypeError(
+                f"scorer {label!r} declares unsupported required parameter(s) {unsupported}; a plain "
+                f"scorer may take only {list(_PLAIN_FIELDS)} (e.g. "
+                f"def scorer(input, output, expected=None, metadata=None))."
+            )
+        return ("plain", tuple(nm for nm in _PLAIN_FIELDS if nm in names))
+    required = [p for p in pos if p.default is p.empty]
+    if len(required) > 1 and not has_varargs:
+        raise TypeError(
+            f"scorer {label!r} has an unsupported signature: {len(required)} required positional "
+            f"parameters. Use `def scorer(ctx)` or "
+            f"`def scorer(input, output, expected=None, metadata=None)`."
+        )
+    if not pos and not has_varargs:
+        raise TypeError(
+            f"scorer {label!r} takes no arguments; a scorer must accept a ScorerContext or "
+            f"(input, output, ...)."
+        )
+    return ("ctx", ())
+
+
+def _bind_scorer_args(scorer: Any, ctx: "ScorerContext") -> tuple[tuple, dict]:
+    """(args, kwargs) to invoke a scorer for one case, per its call plan (see _scorer_call_plan)."""
+    kind, fields = _scorer_call_plan(scorer)
+    if kind == "plain":
+        by = {"input": ctx.input, "output": ctx.output, "expected": ctx.expected,
+              "metadata": ctx.metadata}
+        return ((), {f: by[f] for f in fields})
+    return ((ctx,), {})
 
 
 @dataclasses.dataclass(frozen=True)
@@ -287,10 +369,10 @@ async def _run_case(
                 try:
                     if timeout is not None:
                         output = await asyncio.wait_for(
-                            _await_or_run(task, case.input, executor), timeout
+                            _await_or_run(task, (case.input,), executor=executor), timeout
                         )
                     else:
-                        output = await _await_or_run(task, case.input, executor)
+                        output = await _await_or_run(task, (case.input,), executor=executor)
                     set_span_attribute(
                         task_span, SpanAttributes.SPAN_OUTPUT, serialize_value(output)
                     )
@@ -334,7 +416,8 @@ async def _run_case(
                             scorer_span, SpanAttributes.SPAN_INPUT, serialize_value(scorer_input)
                         )
                         try:
-                            raw = await _await_or_run(scorer, ctx, executor)
+                            s_args, s_kwargs = _bind_scorer_args(scorer, ctx)
+                            raw = await _await_or_run(scorer, s_args, s_kwargs, executor)
                             produced = _stamp_scorer_version(
                                 _normalize_score_like(raw, name), scorer
                             )
@@ -438,6 +521,7 @@ def _validate_config(name, task, scorers, max_concurrency) -> None:
     for s in scorers:
         if not callable(s):
             raise TypeError(f"scorer {s!r} is not callable")
+        _scorer_call_plan(s)  # fail fast on an unsupported scorer signature (not a per-case error)
     if max_concurrency < 1:
         raise ValueError("'max_concurrency' must be >= 1")
 

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -156,13 +156,14 @@ class PlatformTransport:
         #    function name differs from its emitted Score name can no longer silently zero the run;
         #  - multiple scorers with no explicit main have no headline metric here (the engine
         #    requires an explicit main_score for a reported multi-scorer run).
-        n_scorers = len(self.scorer_names) or (len(self.scorer_specs) if self.scorer_specs else 0)
-        self._main_configured = main_score_name is not None
         # Registration reports main_score_name ONLY when the user configured it. A single
         # scorer's metric is late-bound (resolved from what it actually emits) and reported at
         # completion -- never fabricated from the scorer's function name here.
         self.main_score_name = main_score_name
-        self._name_agnostic_main = (not self._main_configured) and n_scorers == 1
+        # NB: `_name_agnostic_main` is a COMPUTED property (below), never cached here. The engine
+        # injects `scorer_specs` AFTER construction (and callers may build the transport explicitly
+        # with no scorer_names), so a value frozen from the empty constructor would leave a single
+        # scorer unresolved and make every case report not_scored / null main.
         self.dataset_version_id = dataset_version_id
         self.client_run_id = client_run_id
         self.pass_threshold = pass_threshold
@@ -181,6 +182,20 @@ class PlatformTransport:
         self._scorer_errors = 0
         self._main_sum = 0.0  # aggregate of the main-score values for run.mainScore
         self._main_count = 0
+
+    @property
+    def _name_agnostic_main(self) -> bool:
+        """A single scorer resolves its emitted metric name-agnostically (its one numeric/boolean
+        score IS the main metric, even when the fn name differs from the emitted Score name).
+
+        Derived from the CURRENT config on every access -- deliberately NOT cached at __init__ --
+        so it reflects `scorer_specs` the engine injects after construction. An explicit
+        `main_score_name` opts out (the configured metric owns it); zero or multiple scorers have
+        no single headline metric here (a reported multi-scorer run requires an explicit main)."""
+        if self.main_score_name is not None:
+            return False
+        n_scorers = len(self.scorer_names) or (len(self.scorer_specs) if self.scorer_specs else 0)
+        return n_scorers == 1
 
     # --- HTTP seam (overridable in tests) ---
     def _request(self, method: str, path: str, body: dict | None = None) -> dict:

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -332,11 +332,33 @@ class PlatformTransport:
         # Already sent inside record_item_result (which carries the full item).
         return None
 
+    def _resolved_scorer_manifest(self, emitted: dict[str, list[str]]) -> list[dict]:
+        """The registration scorer refs augmented with the metrics each DEFINITION actually emitted
+        during the run. The platform keys a metric's policy on the EMITTED-metric name, so a
+        definition whose function name differs from its emitted metric (``grade`` -> ``quality``)
+        must declare that ownership here or the platform can't resolve the metric's threshold/
+        direction. Each emitted metric carries the definition's declared policy (a scorer's
+        declaration governs whatever metric it emits). Rebuilt from the SAME refs registration sent,
+        so completion merges by definition name without dropping the definition's detail."""
+        out: list[dict] = []
+        for ref in self._scorer_refs():
+            metrics = emitted.get(ref["name"])
+            if metrics:
+                policy = {
+                    k: ref[k]
+                    for k in ("value_type", "direction", "threshold")
+                    if ref.get(k) is not None
+                }
+                ref = {**ref, "emitted_metrics": [{"name": m, **policy} for m in metrics]}
+            out.append(ref)
+        return out
+
     def finish_run(
         self,
         run: RunHandle,
         status: str | None = None,
         main_score_name: str | None = None,
+        emitted_metrics: dict[str, list[str]] | None = None,
     ) -> UploadState:
         # Pure reporter: the engine owns the ONE main-score resolution and passes the terminal
         # ``status`` (e.g. "failed" on a misconfiguration) and the resolved ``main_score_name``.
@@ -358,6 +380,13 @@ class PlatformTransport:
         # dependency: deploy that before this SDK, or completion 400s on the unknown key).
         if main_score_name is not None:
             body["main_score_name"] = main_score_name
+        # The RESOLVED scorer->emitted-metric manifest, discovered during execution. The platform
+        # merges it (by definition name) into the stored manifest so each emitted metric's policy is
+        # keyed on the metric name for reconciliation, read-back, and comparison. Additive.
+        if emitted_metrics:
+            manifest = self._resolved_scorer_manifest(emitted_metrics)
+            if manifest:
+                body["scorers"] = manifest
         self._request(
             "POST",
             f"/api/v1/public/evaluation-runs/{self.run_id}/complete",

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -392,6 +392,9 @@ class PlatformTransport:
                 entry["string_value"] = str(v)
             if s.comment is not None:
                 entry["explanation"] = s.comment
+            passed = self._score_passed(s)
+            if passed is not None:
+                entry["passed"] = passed
             payload.append(entry)
         # A failing scorer is a score with an error and null value (never 0). Use the scorer's
         # DECLARED version (from the manifest) so an errored versioned scorer isn't misattributed
@@ -408,6 +411,49 @@ class PlatformTransport:
             if spec.get("name") == name:
                 return spec.get("version") or _UNVERSIONED_SCORER
         return _UNVERSIONED_SCORER
+
+    def _score_policy(self, name: str | None) -> tuple[float, str] | None:
+        """(threshold, direction) for ONE emitted metric, or None when it can't be resolved
+        without guessing. A single scorer's declared policy owns whatever metric it emits, even
+        when the function name differs from the emitted Score name (name-agnostic). With multiple
+        scorers the emitted name must match a declared scorer; an unmatched metric returns None so
+        the platform is told 'unknown', never a fabricated pass/fail. Mirrors the OWNING-scorer
+        rule of ``resolve_main_score_policy`` at per-score granularity."""
+        specs = self.scorer_specs or []
+        owner = specs[0] if len(specs) == 1 else next(
+            (s for s in specs if s.get("name") == name), None
+        )
+        if owner is None:
+            return None
+        threshold = owner.get("threshold")
+        direction = owner.get("direction")
+        return (
+            threshold if threshold is not None else _DEFAULT_PASS_THRESHOLD,
+            str(direction) if direction is not None else "higher_is_better",
+        )
+
+    def _score_passed(self, score: Score) -> bool | None:
+        """SDK-computed pass/fail for one emitted metric, derived at serialization time and never
+        stored on the Score. Boolean: true = pass. Numeric: compared against the OWNING scorer's
+        threshold+direction (the same policy that decides the case status, so a single scorer's
+        main score and its per-score `passed` always agree). Categorical values, a 'none'-direction
+        metric, or a numeric metric whose policy can't be resolved have no pass/fail -> None (the
+        SDK does not guess; the platform stores null)."""
+        v = score.value
+        if isinstance(v, bool):
+            return v
+        n = _numeric_score(v)
+        if n is None:
+            return None
+        policy = self._score_policy(score.name)
+        if policy is None:
+            return None
+        threshold, direction = policy
+        if direction == "lower_is_better":
+            return n <= threshold
+        if direction == "none":
+            return None
+        return n >= threshold  # higher_is_better (the default)
 
     def _main_value(self, scores: list[Score]) -> float | None:
         """The run's main-metric value for one case, or None when unresolved.

--- a/traceroot/eval/transport.py
+++ b/traceroot/eval/transport.py
@@ -53,7 +53,11 @@ class EvalTransport(Protocol):
     def record_scores(self, run: RunHandle, case_id: str, scores: list[Score]) -> None: ...
 
     def finish_run(
-        self, run: RunHandle, status: str | None = None, main_score_name: str | None = None
+        self,
+        run: RunHandle,
+        status: str | None = None,
+        main_score_name: str | None = None,
+        emitted_metrics: dict[str, list[str]] | None = None,
     ) -> UploadState: ...
 
 
@@ -87,10 +91,15 @@ class FakeTransport:
         self.calls.append(("record_scores", case_id))
 
     def finish_run(
-        self, run: RunHandle, status: str | None = None, main_score_name: str | None = None
+        self,
+        run: RunHandle,
+        status: str | None = None,
+        main_score_name: str | None = None,
+        emitted_metrics: dict[str, list[str]] | None = None,
     ) -> UploadState:
         self.calls.append(("finish_run", status))
         self.last_main_score_name = main_score_name
+        self.last_emitted_metrics = emitted_metrics
         return UploadState(status="uploaded", dashboard_url=None)
 
     def publish_dataset(self, dataset_name: str, item_count: int) -> PublishResult:


### PR DESCRIPTION
## Summary

Fixes: traceroot-ai/traceroot#1674

Two changes to the offline-eval scoring model, shipped in parallel in the Python and TypeScript SDKs:

1. **Progressive scorer API.** A scorer can now be an ordinary function of `(input, output, expected?, metadata?)` — no `ScorerContext`, no wrapper — and can return a plain scalar, a single named `Score`, **or** a `{metric: value}` map that emits one score per entry. The `ScorerContext` form still works; the SDK decides how to invoke a scorer by inspecting its parameter *names*, not its arity.
2. **Honest per-score `passed`.** The SDK now computes `passed` for every emitted metric from the policy that owns that metric (threshold + direction) and sends it on the result, instead of leaving pass/fail to be re-derived downstream from a single score. A resolved scorer→emitted-metric ownership manifest is sent at completion so the platform knows which policy owns which metric.

## How it works

**Progressive binding (Python `_scorer_call_plan` / `_bind_scorer_args`).** For each scorer the SDK reads the callable's signature:

- a parameter named `input` or `output` ⟶ **plain** form; the scorer is called by keyword with the declared subset of `(input, output, expected, metadata)`;
- otherwise ⟶ the **context** form `scorer(ctx)`.

Binding is by name so a closure default like `def fn(ctx, _cfg=X)` is never mistaken for a two-arg plain scorer, and an unsupported signature raises an actionable `TypeError` instead of failing cryptically at call time.

**Metric-map returns (`_normalize_score_like`).** A dict result is disambiguated by its keys: presence of `name`/`value` means the single-`Score` shape (both required); any other dict is treated as a metric→scalar mapping and expands to one `Score` per entry. TypeScript mirrors this in `engine.ts`.

**Per-score `passed`.** At completion the SDK resolves each emitted metric to its owning policy and stamps `passed` on the result before it goes over the transport. TypeScript computes the same field in `platform.ts`.

*Python / TypeScript note:* behavior is identical. The TypeScript SDK additionally stamps the canonical `SPAN_TYPE` on TASK and SCORER spans so the platform ingests eval spans correctly — the Python SDK already did this.

## What's included

### Python (`traceroot-py`)
- `traceroot/eval/engine.py` — progressive call-plan (`_scorer_call_plan`, `_bind_scorer_args`, `_await_or_run` now variadic), metric-map normalization in `_normalize_score_like`, emitted-metrics manifest
- `traceroot/eval/platform.py` — SDK-computed per-score `passed` from each metric's owning policy; live single-scorer flag derived from current config, not frozen constructor state
- `traceroot/eval/transport.py` — carry the ownership manifest on the completion payload
- Tests: `test_progressive_scorers.py`, `test_emitted_metrics.py`, additions to `test_platform.py`, `test_reporting_ownership.py`

### TypeScript (`traceroot-ts`)
- `packages/traceroot/src/eval/engine.ts` — progressive/metric-map returns, canonical `SPAN_TYPE` on TASK/SCORER spans, emitted-metrics manifest
- `packages/traceroot/src/eval/platform.ts` — SDK-computed per-score `passed`; live single-scorer flag
- `packages/traceroot/src/eval/transport.ts`, `scorers.ts`
- Tests: `eval-progressive-scorers.test.ts`, `eval-emitted-metrics.test.ts`, `eval-trace.test.ts`, additions to `eval-platform.test.ts`

## Test plan
- [x] Python eval suite green: `.venv/bin/python -m pytest tests/eval -q`
- [x] TypeScript eval suite green: `npx tsx --test tests/eval-*.test.ts`
- [x] TypeScript typecheck clean: `npx tsc --noEmit`
- [x] Plain scorer `def scorer(input, output, expected=None, metadata=None)` runs with no wrapper
- [x] Metric-map return `{ "precision": 0.9, "recall": 0.8 }` emits one score per key
- [x] Single-`Score`/`{name,value}` return still works; a dict with only `value` still errors
- [x] `passed` is resolved per metric from its owning policy and present on every result
- [x] Emitted scorer→metric ownership manifest sent at completion
- [x] TS: TASK and SCORER spans carry the canonical `SPAN_TYPE`

