### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "traceroot"
-version = "0.1.11"
+version = "0.2.0"
 description = "Python SDK for TraceRoot"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2605,7 +2605,7 @@ wheels = [
 
 [[package]]
 name = "traceroot"
-version = "0.1.11"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "openinference-instrumentation" },


### PR DESCRIPTION
Bumps the Python SDK from `0.1.11` to `0.2.0`.

## Why the minor slot

The eval package landed in `main` since `v0.1.11` — a new `traceroot.eval` subpackage with its own test suite, +15,148 / −12 across 85 files. Under 0.x conventions the minor slot carries substantial new surface; `0.1.12` would read as a patch to anyone scanning the changelog.

The change is additive. The only deletions are in `utils.py` and `span_attributes.py`, so existing users upgrading shouldn't hit a break — `0.2.0` signals new capability, not a breaking change.

## What's in here

- `pyproject.toml` — `0.1.11` → `0.2.0`
- `uv.lock` — regenerated with `uv lock` rather than hand-edited

Nothing in code needed touching. `SDK_VERSION` (`traceroot/constants.py:20`) reads from `importlib.metadata.version("traceroot")`, so the OTel tracer version, the `x-traceroot-sdk-version` header, the `traceroot.sdk.version` span attribute, and the eval runner's `sdk_version` field all follow automatically.

The lockfile is included here deliberately — `v0.1.10` shipped without it and needed a follow-up `chore/sync-uv-lock-v0.1.10`.

## Releasing after merge

`publish.yml` triggers on `release: published`, not on tag push, so a bare `git tag` won't publish. After this merges:

```
gh release create v0.2.0 --generate-notes
```

That fires PyPI publish (trusted publishing via OIDC) and the Discord announcer.

Two open questions, neither blocking this PR:
- Auto-generated notes will be a wall of ~30 merged eval PRs; a short hand-written intro would read better in Discord.
- Whether the TS SDK bumps to `0.2.0` alongside this, since the eval surface ships on both and they share a wire contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `traceroot` from 0.1.11 to 0.2.0 to signal the new `traceroot.eval` subpackage shipped since 0.1.11 without breaking changes. Old behavior: SDK reported 0.1.11; new behavior: 0.2.0. Side effects: version-derived telemetry (OTel tracer version, `x-traceroot-sdk-version` header, `traceroot.sdk.version` span attribute, eval runner `sdk_version`) updates automatically via `importlib.metadata`.

**Notes**
- Updates `pyproject.toml` and regenerates `uv.lock`; no code changes.
- Change is additive; existing users do not need to migrate.

**Release**
- After merge, publish with: `gh release create v0.2.0 --generate-notes` (triggers PyPI and Discord).

<sup>Written for commit 6630e938af307dd795bb3fb240359fbc2a7e5e0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

