### PR TITLE
fix(instrumentation): gate LangChain on langchain-core, not the umbrella package

### DIFF
--- a/tests/test_auto_instrumentation.py
+++ b/tests/test_auto_instrumentation.py
@@ -13,6 +13,7 @@ from traceroot.instrumentation._instrumentors import (
     PydanticAIInstrumentor,
 )
 from traceroot.instrumentation.registry import (
+    _BUILTIN_REGISTRY,
     Integration,
     _is_package_installed,
     initialize_integrations,
@@ -38,6 +39,56 @@ def test_integration_enum_values():
 
 def test_integration_exported_from_traceroot():
     assert traceroot.Integration is Integration
+
+
+# =============================================================================
+# Package gating: an entry must gate on the distribution the instrumentor
+# actually patches, not on an umbrella package that is merely conventional.
+# =============================================================================
+
+
+def test_langchain_gates_on_langchain_core():
+    """The LangChain instrumentor patches `langchain_core.callbacks` (its `_MODULE` is
+    "langchain_core"), so langchain-core alone must enable the integration.
+
+    Regression: gating on the umbrella `langchain` distribution silently skipped
+    instrumentation for LangGraph apps, which install langchain-core + langgraph +
+    provider packages and have no reason to pull in `langchain`. The whole agent went
+    untraced -- eval task spans arrived with no children and no cost.
+    """
+    entry = _BUILTIN_REGISTRY[Integration.LANGCHAIN]
+    assert "langchain-core" in entry.all_packages
+    # langchain-core must be FIRST: the skip warning builds its "pip install X" hint
+    # from all_packages[0], so a wrong primary sends users to the wrong package.
+    assert entry.all_packages[0] == "langchain-core"
+    # The umbrella package must still satisfy the gate for existing installs.
+    assert "langchain" in entry.all_packages
+
+
+@patch("traceroot.instrumentation.registry._is_package_installed")
+def test_langchain_instruments_with_only_langchain_core_installed(mock_installed):
+    """End-to-end of the above through initialize_integrations: a LangGraph-style
+    install (langchain-core present, umbrella `langchain` absent) must instrument."""
+    mock_installed.side_effect = lambda pkg: pkg == "langchain-core"
+
+    mock_instrumentor = MagicMock()
+    mock_module = MagicMock()
+    mock_module.LangChainInstrumentor = MagicMock(return_value=mock_instrumentor)
+
+    provider = TracerProvider()
+    with patch("importlib.import_module", return_value=mock_module):
+        result = initialize_integrations(
+            tracer_provider=provider,
+            integrations=[Integration.LANGCHAIN],
+        )
+
+    assert result == [Integration.LANGCHAIN]
+    mock_instrumentor.instrument.assert_called_once_with(tracer_provider=provider)
+
+
+def test_dspy_accepts_legacy_distribution_name():
+    """DSPy ships the same release as both `dspy` and the legacy `dspy-ai`."""
+    assert set(_BUILTIN_REGISTRY[Integration.DSPY].all_packages) == {"dspy", "dspy-ai"}
 
 
 # =============================================================================

--- a/traceroot/instrumentation/registry.py
+++ b/traceroot/instrumentation/registry.py
@@ -66,9 +66,15 @@ _BUILTIN_REGISTRY: dict[Integration, InstrumentorEntry] = {
         class_name="AnthropicInstrumentor",
     ),
     Integration.LANGCHAIN: InstrumentorEntry(
-        package="langchain",
+        # The instrumentor patches `langchain_core.callbacks.BaseCallbackManager`
+        # (its `_MODULE` is "langchain_core"), so langchain-core is the real
+        # dependency. The umbrella `langchain` distribution is optional: a LangGraph
+        # app typically installs only langchain-core + langgraph + provider packages,
+        # and gating on `langchain` skipped instrumentation for those apps entirely.
+        package="langchain-core",
         module_path="openinference.instrumentation.langchain",
         class_name="LangChainInstrumentor",
+        alt_packages=("langchain",),
     ),
     Integration.GOOGLE_GENAI: InstrumentorEntry(
         package="google-genai",
@@ -114,6 +120,9 @@ _BUILTIN_REGISTRY: dict[Integration, InstrumentorEntry] = {
         package="dspy",
         module_path="openinference.instrumentation.dspy",
         class_name="DSPyInstrumentor",
+        # DSPy publishes the same release under both names (`dspy-ai` is the legacy
+        # distribution), so accept either.
+        alt_packages=("dspy-ai",),
     ),
     Integration.GOOGLE_ADK: InstrumentorEntry(
         package="google-adk",


### PR DESCRIPTION
## The bug

The LangChain instrumentor patches `langchain_core.callbacks.BaseCallbackManager` — its `_MODULE` is `"langchain_core"` — so **langchain-core** is the distribution it actually depends on. The registry gated on the umbrella `langchain` package instead.

A LangGraph app typically installs `langchain-core` + `langgraph` + provider packages and has no reason to pull in `langchain`. The gate failed, the integration was skipped, and the failure was silent: the whole agent went untraced, so eval task spans arrived with no children and no cost attribution.

## The fix

`traceroot/instrumentation/registry.py`

- LangChain now gates on `langchain-core`, with `langchain` kept as an alt package so existing installs are unaffected.
- Ordering matters: `langchain-core` is primary because the skip warning builds its `pip install X` hint from `all_packages[0]`, so a wrong primary would point users at the wrong package.
- DSPy also accepts `dspy-ai`, the legacy distribution name for the same release.

Both use the existing `alt_packages` mechanism rather than new machinery — the same pattern `pydantic-ai` already uses with `pydantic-ai-slim`.

## Tests

Three added to `tests/test_auto_instrumentation.py`:

- `test_langchain_gates_on_langchain_core` — pins both membership and the ordering the warning hint depends on.
- `test_langchain_instruments_with_only_langchain_core_installed` — end-to-end through `initialize_integrations` simulating a LangGraph-style install (langchain-core present, umbrella absent); asserts the instrumentor is actually invoked, so it fails on the pre-fix code.
- `test_dspy_accepts_legacy_distribution_name`

`tests/test_auto_instrumentation.py`: 45 passed. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the LangChain integration on `langchain-core` instead of the umbrella `langchain` so LangGraph-style installs instrument correctly; keep `langchain` as an alternative to avoid breaking existing installs. Also accept `dspy-ai` as an alternative distribution for DSPy.

**Review notes**
- Update `traceroot/instrumentation/registry.py`: set `package="langchain-core"` and `alt_packages=("langchain",)`; order matters because the skip warning builds its `pip install X` hint from the first package.
- Add `alt_packages=("dspy-ai",)` for DSPy.
- Add tests to pin `langchain-core` as primary, ensure instrumentation when only `langchain-core` is present, and accept `dspy-ai`.
- No migration required; installs with only `langchain-core` now trace, and existing `langchain` installs continue to work.

<sup>Written for commit 671254eab88869e5c453f8ac8ddb3ef5f3d69da9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

