### PR TITLE
feat(tracing): emit traceroot.span.starts_path for ancestor start times.

### DIFF
--- a/tests/test_span_processor_path.py
+++ b/tests/test_span_processor_path.py
@@ -3,6 +3,8 @@
 Covers:
   - traceroot.span.path set correctly for root / child / deeply nested spans
   - traceroot.span.ids_path set correctly at every depth
+  - traceroot.span.starts_path set correctly and index-aligned with ids_path
+    (ancestor start times as epoch-ns decimal strings, root -> parent)
   - Map-based ancestry lets children inherit full paths even when the parent is
     a NonRecordingSpan (the OpenInference / LangGraph pattern)
   - Map entries are cleaned up on span end (no memory leak)
@@ -49,6 +51,10 @@ def _path(span) -> list[str]:
 
 def _ids(span) -> list[str]:
     return list(span.attributes.get("traceroot.span.ids_path", ()))
+
+
+def _starts(span) -> list[str]:
+    return list(span.attributes.get("traceroot.span.starts_path", ()))
 
 
 def _hex(span_id: int) -> str:
@@ -120,6 +126,48 @@ def test_grandchild_ids_path_is_root_then_mid(proc_setup):
     assert _ids(leaf) == [root_id, mid_id]
 
 
+# ── span.starts_path propagation ──────────────────────────────────────────────
+#
+# starts_path carries each ancestor's real start time (epoch-ns decimal string),
+# index-aligned with ids_path: starts_path[i] is the start of ids_path[i]. Values
+# are asserted against the InMemorySpanExporter-captured spans' .start_time, not
+# mocks.
+
+
+def test_root_span_starts_path_is_empty(proc_setup):
+    tracer, exporter, _ = proc_setup
+    with tracer.start_as_current_span("root"):
+        pass
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert _starts(spans[0]) == []
+
+
+def test_child_starts_path_contains_parent_start(proc_setup):
+    tracer, exporter, _ = proc_setup
+    with tracer.start_as_current_span("root"), tracer.start_as_current_span("child"):
+        pass
+    root = next(s for s in exporter.get_finished_spans() if s.name == "root")
+    child = next(s for s in exporter.get_finished_spans() if s.name == "child")
+    assert _starts(child) == [str(root.start_time)]
+    assert len(_starts(child)) == len(_ids(child))
+
+
+def test_grandchild_starts_path_aligns_with_ids_path(proc_setup):
+    tracer, exporter, _ = proc_setup
+    with (
+        tracer.start_as_current_span("root"),
+        tracer.start_as_current_span("mid"),
+        tracer.start_as_current_span("leaf"),
+    ):
+        pass
+    root = next(s for s in exporter.get_finished_spans() if s.name == "root")
+    mid = next(s for s in exporter.get_finished_spans() if s.name == "mid")
+    leaf = next(s for s in exporter.get_finished_spans() if s.name == "leaf")
+    assert _starts(leaf) == [str(root.start_time), str(mid.start_time)]
+    assert len(_starts(leaf)) == len(_ids(leaf))
+
+
 # ── Map-based ancestry (NonRecordingSpan / remote parent) ─────────────────────
 #
 # OpenInference instruments LangGraph nodes by creating spans whose parent is
@@ -156,6 +204,35 @@ def test_child_inherits_full_ids_path_via_map_when_parent_is_non_recording(proc_
     # Without the map fix this would be [mid_id] only — root ancestry lost.
     assert _ids(leaf_span) == [root_id, mid_id]
     assert _path(leaf_span) == ["root", "mid", "leaf"]
+
+
+def test_child_inherits_starts_path_via_map_when_parent_is_non_recording(proc_setup):
+    tracer, exporter, _ = proc_setup
+
+    with (
+        tracer.start_as_current_span("root"),
+        tracer.start_as_current_span("mid") as mid,
+    ):
+        # Same shape as the ids_path map test: the active span is replaced by
+        # a NonRecordingSpan with the same spanId but no attributes, so the
+        # starts must come from the map, not the parent's attributes.
+        remote_ctx = SpanContext(
+            trace_id=mid.context.trace_id,
+            span_id=mid.context.span_id,
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        non_recording_parent = NonRecordingSpan(remote_ctx)
+        ctx_with_remote = trace.set_span_in_context(non_recording_parent)
+
+        leaf = tracer.start_span("leaf", context=ctx_with_remote)
+        leaf.end()
+
+    root = next(s for s in exporter.get_finished_spans() if s.name == "root")
+    mid = next(s for s in exporter.get_finished_spans() if s.name == "mid")
+    leaf_span = next(s for s in exporter.get_finished_spans() if s.name == "leaf")
+    assert _starts(leaf_span) == [str(root.start_time), str(mid.start_time)]
+    assert len(_starts(leaf_span)) == len(_ids(leaf_span))
 
 
 def test_path_fully_inherited_via_map_for_remote_parent(proc_setup):
@@ -203,6 +280,30 @@ def test_multiple_remote_children_of_same_parent_all_get_correct_ancestry(proc_s
     assert _ids(finished["child2"]) == [root_id, mid_id]
 
 
+def test_multiple_remote_children_of_same_parent_get_correct_starts(proc_setup):
+    tracer, exporter, _ = proc_setup
+
+    with (
+        tracer.start_as_current_span("root") as root,
+        tracer.start_as_current_span("mid") as mid,
+    ):
+        remote_ctx = SpanContext(
+            trace_id=mid.context.trace_id,
+            span_id=mid.context.span_id,
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        ctx_with_remote = trace.set_span_in_context(NonRecordingSpan(remote_ctx))
+        c1 = tracer.start_span("child1", context=ctx_with_remote)
+        c2 = tracer.start_span("child2", context=ctx_with_remote)
+        c1.end()
+        c2.end()
+
+    finished = {s.name: s for s in exporter.get_finished_spans()}
+    assert _starts(finished["child1"]) == [str(root.start_time), str(mid.start_time)]
+    assert _starts(finished["child2"]) == [str(root.start_time), str(mid.start_time)]
+
+
 # ── Map memory / eviction ─────────────────────────────────────────────────────
 #
 # Entries are evicted in on_end (under RLock) to keep memory low. A bounded
@@ -219,6 +320,7 @@ def test_map_entries_removed_after_span_ends(proc_setup):
 
     assert root_hex not in processor._ids_path_by_span_id
     assert root_hex not in processor._name_path_by_span_id
+    assert root_hex not in processor._starts_path_by_span_id
 
 
 def test_map_cleaned_up_for_all_spans_in_hierarchy(proc_setup):
@@ -234,6 +336,58 @@ def test_map_cleaned_up_for_all_spans_in_hierarchy(proc_setup):
 
     assert root_hex not in processor._ids_path_by_span_id
     assert child_hex not in processor._ids_path_by_span_id
+    assert root_hex not in processor._starts_path_by_span_id
+    assert child_hex not in processor._starts_path_by_span_id
+
+
+def test_starts_map_evicted_in_lockstep_via_on_start(proc_setup):
+    """Eviction of the starts map is driven through the real on_start path.
+
+    Creates _PATH_MAP_MAX + 1 sequential root spans without ending them (ending
+    would pop the entries in on_end). The overflow must evict the oldest entry
+    from ALL three maps — including starts. If the starts eviction is dropped
+    from production, this test fails.
+    """
+    from traceroot.transport.span_processor import _PATH_MAP_MAX
+
+    tracer, _, processor = proc_setup
+    spans = [tracer.start_span(f"span-{i}") for i in range(_PATH_MAP_MAX + 1)]
+    first_hex = _hex(spans[0].context.span_id)
+    last_hex = _hex(spans[-1].context.span_id)
+
+    assert first_hex not in processor._ids_path_by_span_id
+    assert first_hex not in processor._name_path_by_span_id
+    assert first_hex not in processor._starts_path_by_span_id
+
+    assert last_hex in processor._ids_path_by_span_id
+    assert last_hex in processor._name_path_by_span_id
+    assert last_hex in processor._starts_path_by_span_id
+    assert len(processor._starts_path_by_span_id) == _PATH_MAP_MAX
+
+    for span in spans:
+        span.end()
+
+
+def test_remote_parent_with_unknown_start_stamps_empty_starts(proc_setup):
+    """A remote parent never seen by this processor has no start time.
+
+    ids_path still records the remote id, but starts_path must stamp [] rather
+    than emit a wrong-length (misaligned) array.
+    """
+    tracer, exporter, _ = proc_setup
+    remote_ctx = SpanContext(
+        trace_id=0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF,
+        span_id=0x0BADCAFE0BADCAFE,
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    ctx_with_remote = trace.set_span_in_context(NonRecordingSpan(remote_ctx))
+    leaf = tracer.start_span("leaf", context=ctx_with_remote)
+    leaf.end()
+
+    leaf_span = exporter.get_finished_spans()[0]
+    assert _ids(leaf_span) == [_hex(0x0BADCAFE0BADCAFE)]
+    assert _starts(leaf_span) == []
 
 
 def test_map_bounded_eviction_at_capacity(proc_setup):
@@ -319,6 +473,7 @@ def test_non_recording_span_not_added_to_map(proc_setup):
     span_hex = _hex(remote_ctx.span_id)
     assert span_hex not in processor._ids_path_by_span_id
     assert span_hex not in processor._name_path_by_span_id
+    assert span_hex not in processor._starts_path_by_span_id
 
 
 def test_non_recording_span_has_no_path_attributes(proc_setup):
@@ -337,6 +492,7 @@ def test_non_recording_span_has_no_path_attributes(proc_setup):
     span_hex = _hex(remote_ctx.span_id)
     assert span_hex not in processor._ids_path_by_span_id
     assert span_hex not in processor._name_path_by_span_id
+    assert span_hex not in processor._starts_path_by_span_id
 
 
 def test_map_stays_empty_when_only_non_recording_spans_processed(proc_setup):
@@ -352,6 +508,7 @@ def test_map_stays_empty_when_only_non_recording_spans_processed(proc_setup):
 
     assert processor._ids_path_by_span_id == {}
     assert processor._name_path_by_span_id == {}
+    assert processor._starts_path_by_span_id == {}
 
 
 # ── Git context attributes ─────────────────────────────────────────────────────

--- a/traceroot/transport/span_processor.py
+++ b/traceroot/transport/span_processor.py
@@ -129,6 +129,7 @@ class TracerootSpanProcessor(BatchSpanProcessor):
         # concurrent sibling's on_start could look it up.
         self._ids_path_by_span_id: _PathMap = OrderedDict()
         self._name_path_by_span_id: _PathMap = OrderedDict()
+        self._starts_path_by_span_id: _PathMap = OrderedDict()
 
     def on_start(self, span, parent_context=None):
         if span.is_recording():
@@ -161,9 +162,12 @@ class TracerootSpanProcessor(BatchSpanProcessor):
                     parent_path: list | None = (
                         self._name_path_by_span_id.get(parent_id_hex) if parent_id_hex else None
                     )
+                    parent_starts: list | None = (
+                        self._starts_path_by_span_id.get(parent_id_hex) if parent_id_hex else None
+                    )
 
                     # Fall back to reading from the active parent span's attributes.
-                    if parent_ids_path is None or parent_path is None:
+                    if parent_ids_path is None or parent_path is None or parent_starts is None:
                         if parent_context is not None:
                             parent_span = otel_trace.get_current_span(parent_context)
                         else:
@@ -177,6 +181,9 @@ class TracerootSpanProcessor(BatchSpanProcessor):
                             raw_ids = attrs.get("traceroot.span.ids_path")
                             if raw_ids is not None:
                                 parent_ids_path = list(raw_ids)
+                            raw_starts = attrs.get("traceroot.span.starts_path")
+                            if raw_starts is not None:
+                                parent_starts = list(raw_starts)
 
                     span_name = getattr(span, "name", "") or ""
 
@@ -195,17 +202,41 @@ class TracerootSpanProcessor(BatchSpanProcessor):
                     else:
                         span_ids_path = []
 
+                    # starts_path: ancestor start times as epoch-nanosecond decimal
+                    # strings, index-aligned with ids_path (starts_path[i] is the
+                    # start of ids_path[i]). The starts map stores each span's
+                    # ancestor starts PLUS its own start, so a child's starts_path
+                    # is exactly the parent's stored list — no append needed.
+                    if parent_id_hex:
+                        span_starts_path = list(parent_starts) if parent_starts is not None else []
+                    else:
+                        span_starts_path = []
+
+                    # Never emit a starts_path that does not index-align with
+                    # ids_path (e.g. a remote parent whose start time is unknown):
+                    # stamp [] instead of a wrong-length array.
+                    if len(span_starts_path) != len(span_ids_path):
+                        span_starts_path = []
+
                     # Store in map so descendant spans can inherit via lookup.
                     # Evict the oldest entry if we're at capacity.
                     span_id_hex = format(span.context.span_id, "016x")
                     if len(self._ids_path_by_span_id) >= _PATH_MAP_MAX:
                         self._ids_path_by_span_id.popitem(last=False)
                         self._name_path_by_span_id.popitem(last=False)
+                        self._starts_path_by_span_id.popitem(last=False)
                     self._ids_path_by_span_id[span_id_hex] = span_ids_path
                     self._name_path_by_span_id[span_id_hex] = span_path
+                    own_start = getattr(span, "start_time", None)
+                    self._starts_path_by_span_id[span_id_hex] = (
+                        span_starts_path + [str(own_start)]
+                        if own_start is not None
+                        else span_starts_path
+                    )
 
                 span.set_attribute("traceroot.span.path", span_path)
                 span.set_attribute("traceroot.span.ids_path", span_ids_path)
+                span.set_attribute("traceroot.span.starts_path", span_starts_path)
 
             except Exception as exc:
                 logger.debug("TracerootSpanProcessor: failed to set path attributes: %s", exc)
@@ -217,6 +248,7 @@ class TracerootSpanProcessor(BatchSpanProcessor):
             span_id_hex = format(span.context.span_id, "016x")
             self._ids_path_by_span_id.pop(span_id_hex, None)
             self._name_path_by_span_id.pop(span_id_hex, None)
+            self._starts_path_by_span_id.pop(span_id_hex, None)
         super().on_end(span)
 
     @property


### PR DESCRIPTION
@XinweiHe @dark-sorceror would appreciate a review when you get a chance. Thanks!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit `traceroot.span.starts_path` with ancestor start times aligned to `traceroot.span.ids_path`, enabling accurate timeline reconstruction and working with `NonRecordingSpan` parents. Previously we emitted only `traceroot.span.path` and `traceroot.span.ids_path`; now spans also include `starts_path`. Root spans emit an empty array; remote parents with unknown starts also produce an empty array to avoid misalignment.

- Adds a bounded `_starts_path_by_span_id` map in `traceroot/transport/span_processor.py`, evicted in lockstep with existing maps on `on_start` and cleaned on `on_end`. Capacity respects `_PATH_MAP_MAX`.
- Propagates `starts_path` via map-based ancestry so children inherit correct starts when the parent is a `NonRecordingSpan`. If parent start is unavailable, `starts_path` is `[]` to preserve index alignment with `ids_path`.
- Sets `traceroot.span.starts_path` as epoch-nanosecond decimal strings and ensures its length matches `traceroot.span.ids_path`.
- Extends tests to cover propagation, alignment, `NonRecordingSpan`/remote cases, and map eviction.

<sup>Written for commit bbc8edf6ff401da63986123b6c95c14836ea132c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

