### PR TITLE
refactor(eval): drop the `data` alias from `evaluate()`; make `dataset` required

### DIFF
--- a/tests/eval/test_dataset_ergonomics.py
+++ b/tests/eval/test_dataset_ergonomics.py
@@ -162,7 +162,7 @@ class TestCloudOnlyErrorIsAccurate:
         with pytest.raises(RuntimeError) as exc:
             evaluate(
                 name="r",
-                data=[EvalCase(input=1, id="c0", expected=1)],
+                dataset=[EvalCase(input=1, id="c0", expected=1)],
                 task=lambda x: x,
                 scorers=[lambda ctx: 1.0],
             )
@@ -179,7 +179,7 @@ class TestCloudOnlyErrorIsAccurate:
         d = Dataset("d")
         d.add(input=1, expected=1)
         with pytest.raises(RuntimeError, match="no credentials were found"):
-            evaluate(name="r", data=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
+            evaluate(name="r", dataset=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
 
 
 class TestMetadataOnlyPush:

--- a/tests/eval/test_engine.py
+++ b/tests/eval/test_engine.py
@@ -24,7 +24,7 @@ def exact(ctx):
 
 class TestBasicRuns:
     def test_sync_task_sync_scorer(self):
-        result = evaluate(name="r", data=_ds(3), task=echo_task, scorers=[exact])
+        result = evaluate(name="r", dataset=_ds(3), task=echo_task, scorers=[exact])
         assert isinstance(result, EvalRunResult)
         assert [it.case_id for it in result.item_results] == ["c0", "c1", "c2"]
         assert result.score_summary["exact"].mean == 1.0
@@ -39,25 +39,25 @@ class TestBasicRuns:
             await asyncio.sleep(0)
             return 1.0 if ctx.output == ctx.expected else 0.0
 
-        result = await evaluate_async(name="r", data=_ds(2), task=atask, scorers=[ascore])
+        result = await evaluate_async(name="r", dataset=_ds(2), task=atask, scorers=[ascore])
         assert result.score_summary["ascore"].mean == 1.0
 
     def test_mixed_sync_async(self):
         async def ascore(ctx):
             return 1.0
 
-        result = evaluate(name="r", data=_ds(2), task=echo_task, scorers=[exact, ascore])
+        result = evaluate(name="r", dataset=_ds(2), task=echo_task, scorers=[exact, ascore])
         assert result.score_summary["exact"].mean == 1.0
         assert result.score_summary["ascore"].mean == 1.0
 
     def test_evaluate_returns_completed_result_not_coroutine(self):
-        result = evaluate(name="r", data=_ds(1), task=echo_task, scorers=[exact])
+        result = evaluate(name="r", dataset=_ds(1), task=echo_task, scorers=[exact])
         assert isinstance(result, EvalRunResult)
         assert not asyncio.iscoroutine(result)
 
     def test_evaluate_works_inside_running_loop(self):
         async def outer():
-            return evaluate(name="r", data=_ds(2), task=echo_task, scorers=[exact])
+            return evaluate(name="r", dataset=_ds(2), task=echo_task, scorers=[exact])
 
         result = asyncio.run(outer())
         assert isinstance(result, EvalRunResult)
@@ -71,7 +71,7 @@ class TestOrderingAndConcurrency:
             await asyncio.sleep((5 - x) * 0.01)
             return x
 
-        result = await evaluate_async(name="r", data=_ds(5), task=slow, scorers=[exact])
+        result = await evaluate_async(name="r", dataset=_ds(5), task=slow, scorers=[exact])
         assert [it.case_id for it in result.item_results] == ["c0", "c1", "c2", "c3", "c4"]
         assert [it.output for it in result.item_results] == [0, 1, 2, 3, 4]
 
@@ -86,7 +86,7 @@ class TestOrderingAndConcurrency:
             return x
 
         await evaluate_async(
-            name="r", data=_ds(10), task=tracked, scorers=[exact], max_concurrency=2
+            name="r", dataset=_ds(10), task=tracked, scorers=[exact], max_concurrency=2
         )
         assert state["peak"] <= 2
 
@@ -98,7 +98,7 @@ class TestFailureIsolation:
                 raise ValueError("nope")
             return x
 
-        result = evaluate(name="r", data=_ds(3), task=boom, scorers=[exact])
+        result = evaluate(name="r", dataset=_ds(3), task=boom, scorers=[exact])
         by_id = {it.case_id: it for it in result.item_results}
         assert by_id["c1"].error is not None
         assert "nope" in by_id["c1"].error
@@ -110,7 +110,7 @@ class TestFailureIsolation:
         def bad(ctx):
             raise RuntimeError("scorer boom")
 
-        result = evaluate(name="r", data=_ds(2), task=echo_task, scorers=[exact, bad])
+        result = evaluate(name="r", dataset=_ds(2), task=echo_task, scorers=[exact, bad])
         it = result.item_results[0]
         assert "bad" in it.scorer_errors
         assert "scorer boom" in it.scorer_errors["bad"]
@@ -120,14 +120,14 @@ class TestFailureIsolation:
         def malformed(ctx):
             return {"value": 1.0}  # missing 'name'
 
-        result = evaluate(name="r", data=_ds(1), task=echo_task, scorers=[malformed])
+        result = evaluate(name="r", dataset=_ds(1), task=echo_task, scorers=[malformed])
         it = result.item_results[0]
         assert "malformed" in it.scorer_errors
 
 
 class TestScoreNormalization:
     def _one(self, scorer):
-        return evaluate(name="r", data=_ds(1), task=echo_task, scorers=[scorer]).item_results[0]
+        return evaluate(name="r", dataset=_ds(1), task=echo_task, scorers=[scorer]).item_results[0]
 
     def test_scalar(self):
         def s(ctx):
@@ -179,53 +179,53 @@ class TestScoreNormalization:
 class TestDataCoercion:
     def test_list_of_eval_cases(self):
         cases = [EvalCase(input=1, id="a", expected=1), EvalCase(input=2, id="b", expected=2)]
-        result = evaluate(name="r", data=cases, task=echo_task, scorers=[exact])
+        result = evaluate(name="r", dataset=cases, task=echo_task, scorers=[exact])
         assert [it.case_id for it in result.item_results] == ["a", "b"]
 
     def test_list_of_dicts(self):
         data = [{"input": 1, "expected": 1}, {"input": 2, "expected": 2}]
-        result = evaluate(name="r", data=data, task=echo_task, scorers=[exact])
+        result = evaluate(name="r", dataset=data, task=echo_task, scorers=[exact])
         assert result.score_summary["exact"].mean == 1.0
 
     def test_dict_missing_input_raises(self):
         with pytest.raises((ValueError, TypeError)):
-            evaluate(name="r", data=[{"expected": 1}], task=echo_task, scorers=[exact])
+            evaluate(name="r", dataset=[{"expected": 1}], task=echo_task, scorers=[exact])
 
     def test_dict_unknown_key_raises(self):
         with pytest.raises((ValueError, TypeError)):
-            evaluate(name="r", data=[{"input": 1, "bogus": 2}], task=echo_task, scorers=[exact])
+            evaluate(name="r", dataset=[{"input": 1, "bogus": 2}], task=echo_task, scorers=[exact])
 
 
 class TestConfigErrors:
     def test_empty_name(self):
         with pytest.raises(ValueError):
-            evaluate(name="", data=_ds(1), task=echo_task, scorers=[exact])
+            evaluate(name="", dataset=_ds(1), task=echo_task, scorers=[exact])
 
     def test_empty_data(self):
         with pytest.raises(ValueError):
-            evaluate(name="r", data=_ds(0), task=echo_task, scorers=[exact])
+            evaluate(name="r", dataset=_ds(0), task=echo_task, scorers=[exact])
 
     def test_non_callable_task(self):
         with pytest.raises((ValueError, TypeError)):
-            evaluate(name="r", data=_ds(1), task="nope", scorers=[exact])
+            evaluate(name="r", dataset=_ds(1), task="nope", scorers=[exact])
 
     def test_empty_scorers(self):
         with pytest.raises(ValueError):
-            evaluate(name="r", data=_ds(1), task=echo_task, scorers=[])
+            evaluate(name="r", dataset=_ds(1), task=echo_task, scorers=[])
 
     def test_non_callable_scorer(self):
         with pytest.raises((ValueError, TypeError)):
-            evaluate(name="r", data=_ds(1), task=echo_task, scorers=["nope"])
+            evaluate(name="r", dataset=_ds(1), task=echo_task, scorers=["nope"])
 
     def test_bad_max_concurrency(self):
         with pytest.raises(ValueError):
-            evaluate(name="r", data=_ds(1), task=echo_task, scorers=[exact], max_concurrency=0)
+            evaluate(name="r", dataset=_ds(1), task=echo_task, scorers=[exact], max_concurrency=0)
 
 
 class TestResultShape:
     def test_uploaded_status_and_no_trace_id_without_provider(self):
         # Cloud-only: the run reports (status uploaded). With no tracer provider registered
         # in this test, the no-op span has no valid context, so the item carries no trace id.
-        result = evaluate(name="r", data=_ds(1), task=echo_task, scorers=[exact])
+        result = evaluate(name="r", dataset=_ds(1), task=echo_task, scorers=[exact])
         assert result.item_results[0].trace_id is None
         assert result.upload_state.status == "uploaded"

--- a/tests/eval/test_evaluate_autopublish.py
+++ b/tests/eval/test_evaluate_autopublish.py
@@ -84,7 +84,7 @@ class TestEvaluateNeverPrompts:
         sync = _existing_sync("rev_from_an_older_push")
         monkeypatch.setattr(sync_mod, "PlatformDatasetSync", lambda *a, **k: sync)
 
-        result = evaluate(name="r", data=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
+        result = evaluate(name="r", dataset=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
 
         assert declining_prompt == []  # the confirmer was never consulted
         assert _published(sync)  # ...and the changed content really was versioned
@@ -99,7 +99,7 @@ class TestEvaluateNeverPrompts:
         sync = _existing_sync(d.snapshot().revision)
         monkeypatch.setattr(sync_mod, "PlatformDatasetSync", lambda *a, **k: sync)
 
-        result = evaluate(name="r", data=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
+        result = evaluate(name="r", dataset=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
 
         assert declining_prompt == []
         assert not _published(sync)  # no new version for identical content
@@ -130,7 +130,7 @@ class TestAutoPublishFailureIsActionable:
         monkeypatch.setattr(sync_mod, "PlatformDatasetSync", lambda *a, **k: sync)
 
         with pytest.raises(RuntimeError) as excinfo:
-            evaluate(name="r", data=_dataset(), task=lambda x: x, scorers=[lambda ctx: 1.0])
+            evaluate(name="r", dataset=_dataset(), task=lambda x: x, scorers=[lambda ctx: 1.0])
 
         assert not isinstance(excinfo.value, DatasetConflictError)
         message = str(excinfo.value)
@@ -145,7 +145,7 @@ class TestAutoPublishFailureIsActionable:
         monkeypatch.setattr(sync_mod, "PlatformDatasetSync", lambda *a, **k: sync)
 
         with pytest.raises(RuntimeError) as excinfo:
-            evaluate(name="r", data=_dataset(), task=lambda x: x, scorers=[lambda ctx: 1.0])
+            evaluate(name="r", dataset=_dataset(), task=lambda x: x, scorers=[lambda ctx: 1.0])
 
         message = str(excinfo.value)
         assert "could not auto-publish dataset 'auto' before the run" in message
@@ -163,11 +163,11 @@ class TestTheRunPinsWhatItScored:
         monkeypatch.setattr(sync_mod, "PlatformDatasetSync", lambda *a, **k: fake)
         d = _dataset()
 
-        first = evaluate(name="r", data=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
+        first = evaluate(name="r", dataset=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
         assert first.dataset.dataset_version_id == "dsv_1"
 
         d.add(input={"m": 2}, expected={"m": 2})  # the content the SECOND run actually scores
-        second = evaluate(name="r", data=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
+        second = evaluate(name="r", dataset=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
 
         assert second.dataset.dataset_version_id == "dsv_2"
         assert len(fake.pushes) == 2
@@ -178,8 +178,8 @@ class TestTheRunPinsWhatItScored:
         monkeypatch.setattr(sync_mod, "PlatformDatasetSync", lambda *a, **k: fake)
         d = _dataset()
 
-        first = evaluate(name="r", data=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
-        second = evaluate(name="r", data=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
+        first = evaluate(name="r", dataset=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
+        second = evaluate(name="r", dataset=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
 
         assert second.dataset.dataset_version_id == first.dataset.dataset_version_id
         assert len(fake.pushes) == 1  # unchanged content never versions
@@ -193,7 +193,7 @@ class TestTheRunPinsWhatItScored:
         platform.remember_pinned_content(d)  # exactly what pull_dataset records
         d.add(input={"m": 3}, expected={"m": 3})
 
-        result = evaluate(name="r", data=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
+        result = evaluate(name="r", dataset=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
 
         assert result.dataset.dataset_version_id == "dsv_1"  # the version that has the new case
         assert len(fake.pushes) == 1
@@ -206,7 +206,7 @@ class TestTheRunPinsWhatItScored:
         sync = _existing_sync(d.snapshot().revision)
         monkeypatch.setattr(sync_mod, "PlatformDatasetSync", lambda *a, **k: sync)
 
-        result = evaluate(name="r", data=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
+        result = evaluate(name="r", dataset=d, task=lambda x: x, scorers=[lambda ctx: 1.0])
 
         assert not _published(sync)
         assert result.dataset.dataset_version_id == "dsv_9"

--- a/tests/eval/test_evaluation.py
+++ b/tests/eval/test_evaluation.py
@@ -1,5 +1,7 @@
 """DS-2: Evaluation object + evaluate() convenience + enriched run result."""
 
+import pytest
+
 from traceroot.eval import (
     Dataset,
     EvalRunResult,
@@ -54,9 +56,10 @@ class TestConvenience:
         run = evaluate(name="q", dataset=_ds(), task=route, scorers=[acc])
         assert run.score_summary["acc"].mean == 1.0
 
-    def test_data_alias(self):
-        run = evaluate(name="q", data=_ds(), task=route, scorers=[acc])
-        assert run.score_summary["acc"].mean == 1.0
+    def test_data_alias_removed(self):
+        # The `data=` alias was dropped; only `dataset=` is accepted now.
+        with pytest.raises(TypeError):
+            evaluate(name="q", data=_ds(), task=route, scorers=[acc])
 
     def test_list_data(self):
         run = evaluate(

--- a/tests/eval/test_evaluation_key.py
+++ b/tests/eval/test_evaluation_key.py
@@ -71,7 +71,7 @@ class TestEvaluateThreadsTheKey:
         t = _transport()
         evaluate(
             name="Nightly regression",
-            data=_ds(),
+            dataset=_ds(),
             task=lambda x: x,
             scorers=[lambda ctx: 1.0],
             transport=t,
@@ -83,7 +83,7 @@ class TestEvaluateThreadsTheKey:
         t = _transport()
         evaluate(
             name="Nightly regression",
-            data=_ds(),
+            dataset=_ds(),
             task=lambda x: x,
             scorers=[lambda ctx: 1.0],
             transport=t,
@@ -94,7 +94,7 @@ class TestEvaluateThreadsTheKey:
         t = _transport(evaluation_key="from-the-transport")
         evaluate(
             name="n",
-            data=_ds(),
+            dataset=_ds(),
             task=lambda x: x,
             scorers=[lambda ctx: 1.0],
             transport=t,

--- a/tests/eval/test_local_flag.py
+++ b/tests/eval/test_local_flag.py
@@ -101,7 +101,7 @@ def spy_transport(monkeypatch):
 
 class TestLocalRunsFullyAndReportsNothing:
     def test_completes_without_credentials(self, no_credentials, no_exfiltration):
-        result = evaluate(name="r", data=_dataset(), task=echo, scorers=[exact], local=True)
+        result = evaluate(name="r", dataset=_dataset(), task=echo, scorers=[exact], local=True)
 
         assert result.case_count == 2
         assert result.errored == 0
@@ -115,13 +115,13 @@ class TestLocalRunsFullyAndReportsNothing:
         self, no_credentials, no_exfiltration
     ):
         result = await evaluate_async(
-            name="r", data=_dataset(), task=echo, scorers=[exact], local=True
+            name="r", dataset=_dataset(), task=echo, scorers=[exact], local=True
         )
         assert result.case_count == 2
         assert result.score_summary["exact"].mean == 1.0
 
     def test_the_run_is_recorded_in_memory(self, no_credentials, no_exfiltration, spy_transport):
-        evaluate(name="r", data=_dataset(), task=echo, scorers=[exact], local=True)
+        evaluate(name="r", dataset=_dataset(), task=echo, scorers=[exact], local=True)
 
         assert len(spy_transport) == 1
         kinds = [c[0] for c in spy_transport[0].calls]
@@ -145,7 +145,7 @@ class TestLocalOnASyncedDataset:
     def test_synced_dataset_runs_local(self, credentials, no_exfiltration):
         d = _synced_dataset()
 
-        result = evaluate(name="r", data=d, task=echo, scorers=[exact], local=True)
+        result = evaluate(name="r", dataset=d, task=echo, scorers=[exact], local=True)
 
         assert result.case_count == 2
         assert result.run_id is None
@@ -160,7 +160,7 @@ class TestMutualExclusion:
         with pytest.raises(ValueError, match=_MUTUALLY_EXCLUSIVE):
             evaluate(
                 name="r",
-                data=_dataset(),
+                dataset=_dataset(),
                 task=echo,
                 scorers=[exact],
                 local=True,
@@ -171,7 +171,7 @@ class TestMutualExclusion:
         with pytest.raises(ValueError, match=_MUTUALLY_EXCLUSIVE):
             evaluate(
                 name="r",
-                data=_dataset(),
+                dataset=_dataset(),
                 task=echo,
                 scorers=[exact],
                 local=True,
@@ -196,9 +196,9 @@ class TestEquivalentToAnExplicitFakeTransport:
     ):
         explicit = FakeTransport()
         via_transport = evaluate(
-            name="r", data=_dataset(), task=echo, scorers=[exact], transport=explicit
+            name="r", dataset=_dataset(), task=echo, scorers=[exact], transport=explicit
         )
-        via_local = evaluate(name="r", data=_dataset(), task=echo, scorers=[exact], local=True)
+        via_local = evaluate(name="r", dataset=_dataset(), task=echo, scorers=[exact], local=True)
 
         assert _summary(via_local) == _summary(via_transport)
         assert len(spy_transport) == 1  # only the local run selected one for itself
@@ -231,7 +231,7 @@ class TestDefaultPathUnchanged:
         reported = FakeTransport()
         monkeypatch.setattr(engine, "_auto_transport", lambda *a, **k: reported)
 
-        result = evaluate(name="r", data=_dataset(), task=echo, scorers=[exact])
+        result = evaluate(name="r", dataset=_dataset(), task=echo, scorers=[exact])
 
         assert published == ["local-flag"]
         assert [c[0] for c in reported.calls].count("create_run") == 1
@@ -261,7 +261,7 @@ class TestLocalSuppressesGlobalAutoInit:
             seen_suppressed.append(decorators._is_global_auto_init_suppressed())
             return x
 
-        evaluate(name="r", data=_dataset(), task=task, scorers=[exact], local=True)
+        evaluate(name="r", dataset=_dataset(), task=task, scorers=[exact], local=True)
 
         assert seen_suppressed and all(seen_suppressed)  # suppressed during every case
         assert brought_up == []  # lazy bring-up never happened
@@ -279,6 +279,6 @@ class TestLocalSuppressesGlobalAutoInit:
             seen_suppressed.append(decorators._is_global_auto_init_suppressed())
             return x
 
-        evaluate(name="r", data=_synced_dataset(), task=task, scorers=[exact])
+        evaluate(name="r", dataset=_synced_dataset(), task=task, scorers=[exact])
 
         assert seen_suppressed and not any(seen_suppressed)  # never suppressed on the reported path

--- a/tests/eval/test_local_no_creds.py
+++ b/tests/eval/test_local_no_creds.py
@@ -26,7 +26,7 @@ def exact(ctx):
 
 
 try:
-    evaluate(name="r", data=ds, task=task, scorers=[exact])
+    evaluate(name="r", dataset=ds, task=task, scorers=[exact])
 except RuntimeError as e:
     assert "reports to the TraceRoot platform" in str(e), str(e)
     print("CLOUD_ONLY_RAISED")

--- a/tests/eval/test_platform.py
+++ b/tests/eval/test_platform.py
@@ -754,7 +754,7 @@ class TestReportingDefaults:
         # A remote dataset but no credentials -> nothing to report to -> raise (cloud-only).
         calls = self._spy(monkeypatch)
         with pytest.raises(RuntimeError, match="reports to the TraceRoot platform"):
-            evaluate(name="r", data=self._remote_ds(), task=echo, scorers=[acc])
+            evaluate(name="r", dataset=self._remote_ds(), task=echo, scorers=[acc])
         assert calls == []
 
     @pytest.mark.no_default_transport
@@ -765,7 +765,7 @@ class TestReportingDefaults:
         calls = self._spy(monkeypatch)
         with pytest.raises(RuntimeError, match="reports to the TraceRoot platform"):
             self._with_creds(
-                lambda: evaluate(name="r", data=[{"input": {"m": 0}}], task=echo, scorers=[acc])
+                lambda: evaluate(name="r", dataset=[{"input": {"m": 0}}], task=echo, scorers=[acc])
             )
         assert calls == []
 
@@ -773,7 +773,7 @@ class TestReportingDefaults:
     def test_remote_dataset_with_creds_uploads(self, monkeypatch):
         calls = self._spy(monkeypatch)
         result = self._with_creds(
-            lambda: evaluate(name="r", data=self._remote_ds(), task=echo, scorers=[acc])
+            lambda: evaluate(name="r", dataset=self._remote_ds(), task=echo, scorers=[acc])
         )
         assert result.upload_state.status == "uploaded"
         assert result.run_id == "run_1"
@@ -783,7 +783,7 @@ class TestReportingDefaults:
     def test_dataset_id_with_creds_uploads(self, monkeypatch):
         calls = self._spy(monkeypatch)
         result = self._with_creds(
-            lambda: evaluate(name="r", data=_ds(2), task=echo, scorers=[acc], dataset_id="ds_1")
+            lambda: evaluate(name="r", dataset=_ds(2), task=echo, scorers=[acc], dataset_id="ds_1")
         )
         assert result.upload_state.status == "uploaded"
         assert result.dataset.dataset_id == "ds_1"
@@ -805,7 +805,7 @@ class TestReportingDefaults:
         transport = PlatformTransport(
             "ds_1", scorer_names=["acc"], api_key="tr-x", host_url="https://h"
         )
-        result = evaluate(name="r", data=_ds(2), task=echo, scorers=[acc], report_to=transport)
+        result = evaluate(name="r", dataset=_ds(2), task=echo, scorers=[acc], report_to=transport)
         assert result.upload_state.status == "uploaded"
         paths = recorded["paths"]
         assert paths[0] == "/api/v1/public/evaluation-runs"

--- a/tests/eval/test_public_api.py
+++ b/tests/eval/test_public_api.py
@@ -63,6 +63,6 @@ def test_end_to_end_via_top_level():
     def routing(ctx):
         return 1.0 if ctx.output == ctx.expected else 0.0
 
-    result = traceroot.evaluate(name="routing-v2", data=ds, task=task, scorers=[routing])
+    result = traceroot.evaluate(name="routing-v2", dataset=ds, task=task, scorers=[routing])
     assert result.score_summary["routing"].mean == 1.0
     assert result.upload_state.status == "uploaded"

--- a/tests/eval/test_scorer_metadata.py
+++ b/tests/eval/test_scorer_metadata.py
@@ -162,7 +162,7 @@ class TestRetainedSpecsMatchTheRunsEffectivePolicy:
         ds = Dataset(name="d")
         ds.upsert(EvalCase(input=1, id="c0", expected=1))
 
-        run = evaluate(name="r", data=ds, task=lambda x: x, scorers=[acc], transport=t)
+        run = evaluate(name="r", dataset=ds, task=lambda x: x, scorers=[acc], transport=t)
 
         assert run.scorer_specs == custom  # not describe_scorers([acc]) (threshold 0.9)
 
@@ -177,7 +177,7 @@ class TestRetainedSpecsMatchTheRunsEffectivePolicy:
         ds.upsert(EvalCase(input=1, id="c0", expected=1))
 
         run = evaluate(
-            name="r", data=ds, task=lambda x: x, scorers=[acc], transport=FakeTransport()
+            name="r", dataset=ds, task=lambda x: x, scorers=[acc], transport=FakeTransport()
         )
 
         assert run.scorer_specs == describe_scorers([acc])

--- a/tests/eval/test_trace_native.py
+++ b/tests/eval/test_trace_native.py
@@ -180,7 +180,9 @@ class TestEvalAttributes:
         assert scorer.attributes["traceroot.eval.score_value"] == 1.0
 
     def test_run_name_on_all_spans(self, memory_exporter):
-        evaluate(name="routing-v2", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(
+            name="routing-v2", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported()
+        )
         by = _by_name(memory_exporter.get_finished_spans())
         for span in (by["evaluation-item"], by["task"], by["exact"]):
             assert span.attributes["traceroot.eval.run_name"] == "routing-v2"
@@ -303,7 +305,9 @@ class TestEvalTraceIdentityContract:
 
 class TestTraceIdAndErrors:
     def test_trace_id_returned_with_provider(self, memory_exporter):
-        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        result = evaluate(
+            name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported()
+        )
         item = result.item_results[0]
         assert item.trace_id is not None
         # matches the emitted evaluation-item root trace id
@@ -316,7 +320,9 @@ class TestTraceIdAndErrors:
                 raise ValueError("kaboom")
             return x
 
-        result = evaluate(name="r", dataset=_ds(3), task=boom, scorers=[exact], report_to=_reported())
+        result = evaluate(
+            name="r", dataset=_ds(3), task=boom, scorers=[exact], report_to=_reported()
+        )
         by_id = {it.case_id: it for it in result.item_results}
         assert "kaboom" in by_id["c1"].error
         assert by_id["c0"].error is None and by_id["c2"].error is None
@@ -333,7 +339,9 @@ class TestReportedTraceExport:
     to its emitted trace id."""
 
     def test_reported_eval_exports_and_links_trace_id(self, memory_exporter):
-        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        result = evaluate(
+            name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported()
+        )
         spans = memory_exporter.get_finished_spans()
         assert sorted(s.name for s in spans) == ["evaluation-item", "exact", "task"]
         item = result.item_results[0]
@@ -371,7 +379,9 @@ class TestUsageAttributionHierarchy:
                 assert not any(("token" in k) or ("cost" in k) for k in keys), keys
 
     def test_trace_id_links_result_to_the_emitted_trace(self, memory_exporter):
-        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        result = evaluate(
+            name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported()
+        )
         root = _by_name(memory_exporter.get_finished_spans())["evaluation-item"]
         assert result.item_results[0].trace_id == format(root.context.trace_id, "032x")
 
@@ -426,7 +436,9 @@ class TestLlmJudgeTrace:
             messages=[{"role": "user", "content": "ANSWER:\n{{output}}"}],
             complete=lambda model, messages: "0.8",
         )
-        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[judge], report_to=_reported())
+        result = evaluate(
+            name="r", dataset=_ds(1), task=echo, scorers=[judge], report_to=_reported()
+        )
 
         by = _by_name(memory_exporter.get_finished_spans())
         assert "llm_judge:conciseness" in by  # a custom complete is self-instrumented
@@ -466,7 +478,9 @@ class TestLlmJudgeTokenCounts:
         monkeypatch.setattr(judge_mod, "_default_complete", lambda model, messages: ("0.8", usage))
 
     def _run(self, judge, memory_exporter):
-        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[judge], report_to=_reported())
+        result = evaluate(
+            name="r", dataset=_ds(1), task=echo, scorers=[judge], report_to=_reported()
+        )
         return result, _by_name(memory_exporter.get_finished_spans())
 
     def test_judge_span_carries_the_provider_token_counts(self, memory_exporter, monkeypatch):

--- a/tests/eval/test_trace_native.py
+++ b/tests/eval/test_trace_native.py
@@ -49,13 +49,13 @@ class TestSpanKindExtension:
 
 class TestSpanHierarchy:
     def test_three_span_kinds_per_case(self, memory_exporter):
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         spans = memory_exporter.get_finished_spans()
         names = sorted(s.name for s in spans)
         assert names == ["evaluation-item", "exact", "task"]
 
     def test_task_parents_under_root_scorer_sibling_of_task(self, memory_exporter):
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         by = _by_name(memory_exporter.get_finished_spans())
         root, task, scorer = by["evaluation-item"], by["task"], by["exact"]
         assert root.parent is None
@@ -72,7 +72,7 @@ class TestSpanHierarchy:
             return inner(x)
 
         evaluate(
-            name="r", data=_ds(1), task=task_with_inner, scorers=[exact], report_to=_reported()
+            name="r", dataset=_ds(1), task=task_with_inner, scorers=[exact], report_to=_reported()
         )
         by = _by_name(memory_exporter.get_finished_spans())
         assert "inner_llm" in by
@@ -89,7 +89,7 @@ class TestSpanHierarchy:
         from traceroot.eval import evaluate_async
 
         await evaluate_async(
-            name="r", data=_ds(1), task=atask, scorers=[exact], report_to=_reported()
+            name="r", dataset=_ds(1), task=atask, scorers=[exact], report_to=_reported()
         )
         by = _by_name(memory_exporter.get_finished_spans())
         assert by["inner_async"].parent.span_id == by["task"].context.span_id
@@ -99,7 +99,7 @@ class TestConcurrencyIsolation:
     def test_concurrent_cases_do_not_tangle(self, memory_exporter):
         evaluate(
             name="r",
-            data=_ds(5),
+            dataset=_ds(5),
             task=echo,
             scorers=[exact],
             max_concurrency=5,
@@ -127,15 +127,15 @@ class TestLocalTracePrivacy:
     either -- even when the process has a configured, exporting tracer provider."""
 
     def test_local_run_exports_no_spans(self, memory_exporter):
-        evaluate(name="r", data=_ds(3), task=echo, scorers=[exact], local=True)
+        evaluate(name="r", dataset=_ds(3), task=echo, scorers=[exact], local=True)
         assert memory_exporter.get_finished_spans() == ()
 
     def test_the_same_run_reported_does_export(self, memory_exporter):
-        evaluate(name="r", data=_ds(3), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=_ds(3), task=echo, scorers=[exact], report_to=_reported())
         assert len(memory_exporter.get_finished_spans()) == 9  # 3 cases x root/task/scorer
 
     def test_local_case_carries_no_trace_id(self, memory_exporter):
-        result = evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], local=True)
+        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], local=True)
         # No exported trace exists, so there is nothing for the item to link to.
         assert result.item_results[0].trace_id is None
 
@@ -151,7 +151,7 @@ class TestLocalTracePrivacy:
 class TestEvalAttributes:
     def test_root_attributes(self, memory_exporter):
         ds = _ds(1, metadata={"cat": "x"}, source_trace_id="t1", source_span_id="s1")
-        evaluate(name="routing-v2", data=ds, task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="routing-v2", dataset=ds, task=echo, scorers=[exact], report_to=_reported())
         root = _by_name(memory_exporter.get_finished_spans())["evaluation-item"]
         a = root.attributes
         assert a[SpanAttributes.SPAN_TYPE] == "evaluation"
@@ -165,12 +165,12 @@ class TestEvalAttributes:
     def test_has_expected_false_when_absent(self, memory_exporter):
         ds = Dataset(name="d")
         ds.upsert(EvalCase(input=1, id="c0"))  # no expected
-        evaluate(name="r", data=ds, task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=ds, task=echo, scorers=[exact], report_to=_reported())
         root = _by_name(memory_exporter.get_finished_spans())["evaluation-item"]
         assert root.attributes["traceroot.eval.has_expected"] is False
 
     def test_task_and_scorer_attributes(self, memory_exporter):
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         by = _by_name(memory_exporter.get_finished_spans())
         assert by["task"].attributes[SpanAttributes.SPAN_TYPE] == "task"
         assert by["task"].attributes["traceroot.eval.task_name"] == "echo"
@@ -180,13 +180,13 @@ class TestEvalAttributes:
         assert scorer.attributes["traceroot.eval.score_value"] == 1.0
 
     def test_run_name_on_all_spans(self, memory_exporter):
-        evaluate(name="routing-v2", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="routing-v2", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         by = _by_name(memory_exporter.get_finished_spans())
         for span in (by["evaluation-item"], by["task"], by["exact"]):
             assert span.attributes["traceroot.eval.run_name"] == "routing-v2"
 
     def test_task_input_output_captured(self, memory_exporter):
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         task = _by_name(memory_exporter.get_finished_spans())["task"]
         assert SpanAttributes.SPAN_INPUT in task.attributes
         assert SpanAttributes.SPAN_OUTPUT in task.attributes
@@ -197,7 +197,7 @@ class TestEvalSpanIO:
     so the trace viewer renders them like any other span (and diff mode has content)."""
 
     def test_root_carries_case_input_and_candidate_output(self, memory_exporter):
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         root = _by_name(memory_exporter.get_finished_spans())["evaluation-item"]
         assert root.attributes[SpanAttributes.SPAN_INPUT] == 0  # the case input
         assert root.attributes[SpanAttributes.SPAN_OUTPUT] == 0  # the candidate output
@@ -206,19 +206,19 @@ class TestEvalSpanIO:
         def boom(x):
             raise ValueError("kaboom")
 
-        evaluate(name="r", data=_ds(1), task=boom, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=boom, scorers=[exact], report_to=_reported())
         root = _by_name(memory_exporter.get_finished_spans())["evaluation-item"]
         assert root.attributes[SpanAttributes.SPAN_INPUT] == 0
         assert "kaboom" in root.attributes[SpanAttributes.SPAN_OUTPUT]  # task error as output
 
     def test_scorer_input_has_candidate_and_expected(self, memory_exporter):
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         scorer = _by_name(memory_exporter.get_finished_spans())["exact"]
         inp = scorer.attributes[SpanAttributes.SPAN_INPUT]
         assert "candidate" in inp and "expected" in inp  # what the scorer compared
 
     def test_scorer_output_has_score_value(self, memory_exporter):
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         scorer = _by_name(memory_exporter.get_finished_spans())["exact"]
         out = scorer.attributes[SpanAttributes.SPAN_OUTPUT]
         assert "value" in out and "1.0" in out  # score value + explanation slot
@@ -227,14 +227,14 @@ class TestEvalSpanIO:
         def broken(ctx):
             raise RuntimeError("judge down")
 
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[broken], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[broken], report_to=_reported())
         scorer = _by_name(memory_exporter.get_finished_spans())["broken"]
         assert "judge down" in scorer.attributes[SpanAttributes.SPAN_OUTPUT]
 
     def test_scorer_input_includes_target_span_id_when_present(self, memory_exporter):
         ds = Dataset(name="d")
         ds.upsert(EvalCase(input=0, id="c0", expected=0, score_target_span_id="span-xyz"))
-        evaluate(name="r", data=ds, task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=ds, task=echo, scorers=[exact], report_to=_reported())
         scorer = _by_name(memory_exporter.get_finished_spans())["exact"]
         assert "span-xyz" in scorer.attributes[SpanAttributes.SPAN_INPUT]
 
@@ -263,7 +263,7 @@ class TestEvalTraceIdentityContract:
         )
         result = evaluate(
             name="billing-routing",
-            data=ds,
+            dataset=ds,
             task=echo,
             scorers=[exact],
             candidate_version="cand-42",
@@ -292,7 +292,7 @@ class TestEvalTraceIdentityContract:
     def test_optional_identity_absent_when_unknown(self, memory_exporter):
         # A local inline run has no run_id / dataset_version_id / candidate_version:
         # those keys are omitted (not stamped as empty), but core identity stays.
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         a = _by_name(memory_exporter.get_finished_spans())["evaluation-item"].attributes
         assert SpanAttributes.EVAL_RUN_ID not in a
         assert SpanAttributes.EVAL_DATASET_VERSION_ID not in a
@@ -303,7 +303,7 @@ class TestEvalTraceIdentityContract:
 
 class TestTraceIdAndErrors:
     def test_trace_id_returned_with_provider(self, memory_exporter):
-        result = evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         item = result.item_results[0]
         assert item.trace_id is not None
         # matches the emitted evaluation-item root trace id
@@ -316,7 +316,7 @@ class TestTraceIdAndErrors:
                 raise ValueError("kaboom")
             return x
 
-        result = evaluate(name="r", data=_ds(3), task=boom, scorers=[exact], report_to=_reported())
+        result = evaluate(name="r", dataset=_ds(3), task=boom, scorers=[exact], report_to=_reported())
         by_id = {it.case_id: it for it in result.item_results}
         assert "kaboom" in by_id["c1"].error
         assert by_id["c0"].error is None and by_id["c2"].error is None
@@ -333,7 +333,7 @@ class TestReportedTraceExport:
     to its emitted trace id."""
 
     def test_reported_eval_exports_and_links_trace_id(self, memory_exporter):
-        result = evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         spans = memory_exporter.get_finished_spans()
         assert sorted(s.name for s in spans) == ["evaluation-item", "exact", "task"]
         item = result.item_results[0]
@@ -354,7 +354,7 @@ class TestUsageAttributionHierarchy:
         def llm_scorer(ctx):
             return judge(ctx.output)  # a judge LLM call inside a scorer
 
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[llm_scorer], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[llm_scorer], report_to=_reported())
         by = _by_name(memory_exporter.get_finished_spans())
         # the judge LLM span is a child of the SCORER span (usage attributes to the judge),
         # NOT the task span.
@@ -362,7 +362,7 @@ class TestUsageAttributionHierarchy:
         assert by["llm_scorer"].parent.span_id == by["evaluation-item"].context.span_id
 
     def test_eval_wrapper_spans_fabricate_no_tokens_or_cost(self, memory_exporter):
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         wrapper_names = {"evaluation-item", "task", "exact"}
         for span in memory_exporter.get_finished_spans():
             if span.name in wrapper_names:
@@ -371,7 +371,7 @@ class TestUsageAttributionHierarchy:
                 assert not any(("token" in k) or ("cost" in k) for k in keys), keys
 
     def test_trace_id_links_result_to_the_emitted_trace(self, memory_exporter):
-        result = evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], report_to=_reported())
+        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], report_to=_reported())
         root = _by_name(memory_exporter.get_finished_spans())["evaluation-item"]
         assert result.item_results[0].trace_id == format(root.context.trace_id, "032x")
 
@@ -386,7 +386,7 @@ class TestLlmJudgeTrace:
             messages=[{"role": "user", "content": "ANSWER:\n{{output}}"}],
             complete=lambda model, messages: "0.8",  # deterministic, no network
         )
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[judge], report_to=_reported())
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[judge], report_to=_reported())
 
         by = _by_name(memory_exporter.get_finished_spans())
         # the judge's model call is its own LLM span, nested under the scorer span
@@ -426,7 +426,7 @@ class TestLlmJudgeTrace:
             messages=[{"role": "user", "content": "ANSWER:\n{{output}}"}],
             complete=lambda model, messages: "0.8",
         )
-        result = evaluate(name="r", data=_ds(1), task=echo, scorers=[judge], report_to=_reported())
+        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[judge], report_to=_reported())
 
         by = _by_name(memory_exporter.get_finished_spans())
         assert "llm_judge:conciseness" in by  # a custom complete is self-instrumented
@@ -466,7 +466,7 @@ class TestLlmJudgeTokenCounts:
         monkeypatch.setattr(judge_mod, "_default_complete", lambda model, messages: ("0.8", usage))
 
     def _run(self, judge, memory_exporter):
-        result = evaluate(name="r", data=_ds(1), task=echo, scorers=[judge], report_to=_reported())
+        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[judge], report_to=_reported())
         return result, _by_name(memory_exporter.get_finished_spans())
 
     def test_judge_span_carries_the_provider_token_counts(self, memory_exporter, monkeypatch):

--- a/tests/eval/test_transport.py
+++ b/tests/eval/test_transport.py
@@ -27,13 +27,13 @@ class TestCloudOnlyDefault:
         # Cloud-only: with no credentials + an unsynced (inline) dataset there is nothing to
         # report to, so evaluate() raises rather than silently running locally.
         with pytest.raises(RuntimeError, match="reports to the TraceRoot platform"):
-            evaluate(name="r", data=_ds(1), task=echo, scorers=[exact])
+            evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact])
 
 
 class TestFakeTransportWiring:
     def test_call_order_single_case(self):
         fake = FakeTransport()
-        evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], transport=fake)
+        evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], transport=fake)
         kinds = [c[0] for c in fake.calls]
         assert kinds[0] == "create_run"
         assert kinds[-1] == "finish_run"
@@ -44,7 +44,7 @@ class TestFakeTransportWiring:
     def test_register_before_result_for_every_case(self):
         fake = FakeTransport()
         evaluate(
-            name="r", data=_ds(4), task=echo, scorers=[exact], transport=fake, max_concurrency=1
+            name="r", dataset=_ds(4), task=echo, scorers=[exact], transport=fake, max_concurrency=1
         )
         for cid in ("c0", "c1", "c2", "c3"):
             reg = next(
@@ -62,17 +62,17 @@ class TestFakeTransportWiring:
             return x
 
         fake = FakeTransport()
-        evaluate(name="r", data=_ds(3), task=boom, scorers=[exact], transport=fake)
+        evaluate(name="r", dataset=_ds(3), task=boom, scorers=[exact], transport=fake)
         registered = {c[1] for c in fake.calls if c[0] == "register_item"}
         assert registered == {"c0", "c1", "c2"}  # including the failing c1
 
     def test_single_finish_run(self):
         fake = FakeTransport()
-        evaluate(name="r", data=_ds(3), task=echo, scorers=[exact], transport=fake)
+        evaluate(name="r", dataset=_ds(3), task=echo, scorers=[exact], transport=fake)
         assert sum(1 for c in fake.calls if c[0] == "finish_run") == 1
 
     def test_explicit_transport_reports_uploaded(self):
         fake = FakeTransport()
-        result = evaluate(name="r", data=_ds(1), task=echo, scorers=[exact], transport=fake)
+        result = evaluate(name="r", dataset=_ds(1), task=echo, scorers=[exact], transport=fake)
         assert any(c[0] == "create_run" for c in fake.calls)
         assert result.upload_state.status == "uploaded"

--- a/traceroot/eval/evaluation.py
+++ b/traceroot/eval/evaluation.py
@@ -109,18 +109,10 @@ class Evaluation:
         return await _run_async(**self._kwargs(overrides))
 
 
-def _resolve_dataset(dataset: DataSource | None, data: DataSource | None) -> DataSource:
-    source = dataset if dataset is not None else data
-    if source is None:
-        raise ValueError("evaluate() requires 'dataset' (or the 'data' alias)")
-    return source
-
-
 def evaluate(
     *,
     name: str,
-    dataset: DataSource | None = None,
-    data: DataSource | None = None,  # alias for dataset
+    dataset: DataSource,
     task: Callable[[Any], Any],
     scorers: Sequence[Callable[[ScorerContext], Any]],
     max_concurrency: int = 10,
@@ -137,15 +129,16 @@ def evaluate(
     progress: bool | None = None,
     retry: Any = None,
 ) -> EvalRunResult:
-    """Construct-and-run an :class:`Evaluation`. ``dataset=`` is primary; ``data=`` is an alias.
+    """Construct-and-run an :class:`Evaluation`.
 
+    ``dataset`` is a ``Dataset`` / ``DatasetSnapshot`` or an inline ``list`` of cases. Reporting to
+    the platform requires a synced dataset, so an inline list must be run with ``local=True``.
     ``local=True`` is the shortcut for ``transport=FakeTransport()``: the run executes in full and
-    returns a complete result, but reports nowhere -- no credentials, no dataset publish, no run
-    record. Pass one or the other, never both.
+    returns a complete result, but reports nowhere -- no credentials, no dataset publish, no run record.
     """
     return Evaluation(
         name=name,
-        dataset=_resolve_dataset(dataset, data),
+        dataset=dataset,
         task=task,
         scorers=scorers,
         max_concurrency=max_concurrency,
@@ -166,8 +159,7 @@ def evaluate(
 async def evaluate_async(
     *,
     name: str,
-    dataset: DataSource | None = None,
-    data: DataSource | None = None,
+    dataset: DataSource,
     task: Callable[[Any], Any],
     scorers: Sequence[Callable[[ScorerContext], Any]],
     max_concurrency: int = 10,
@@ -187,7 +179,7 @@ async def evaluate_async(
     """Async form of :func:`evaluate`."""
     return await Evaluation(
         name=name,
-        dataset=_resolve_dataset(dataset, data),
+        dataset=dataset,
         task=task,
         scorers=scorers,
         max_concurrency=max_concurrency,


### PR DESCRIPTION
## Summary

Fixes: traceroot-ai/traceroot#1965

`evaluate()` / `evaluate_async()` took **two** parameters for one slot — `dataset=` and `data=` — as pure aliases: same union type (`DataSource = Dataset | DatasetSnapshot | Sequence[EvalCase | dict]`), and `_resolve_dataset()` just picked whichever was non-`None` (`dataset` silently winning when both were passed). There is no rule that tells them apart, so the pair can't be documented honestly.

This is a clean break — `data` is removed entirely and `dataset` is now **required**. A missing dataset becomes a signature/type error at the call site instead of a runtime `ValueError`. No deprecation window: evals are unreleased as a documented feature, so there are no external callers to migrate.

The `Evaluation` class already accepted only `dataset`, so this makes the two public surfaces agree.

## What changed

`traceroot/eval/evaluation.py` (only file touched):

- Deleted the `_resolve_dataset(dataset, data)` helper.
- Removed the `data: DataSource | None = None` parameter from both `evaluate()` and `evaluate_async()`.
- Changed `dataset` from `DataSource | None = None` (defaulted) to `dataset: DataSource` (required, no default) on both functions.
- Both call sites now pass `dataset=dataset` straight into the `Evaluation` constructor instead of `dataset=_resolve_dataset(dataset, data)`.
- Updated the `evaluate()` docstring: dropped the "`dataset=` is primary; `data=` is an alias" / "Pass one or the other, never both" language; added the actual rule — an inline `list` reports nowhere, so it must be run with `local=True`.

The `Evaluation` class signature (`dataset: DataSource`, already required) is unchanged, so the convenience function and the class now agree.

## Cross-language parity

The identical change lands on `refactor/eval-drop-data-alias` in the TypeScript SDK (`traceroot-ts`): `EvaluateOptions.data` removed, `dataset` made required, resolution reads `options.dataset` directly. Both SDKs now expose a single, required `dataset` parameter with the same union type.

## Notes for reviewers

- Branched off `main`, independent of the separate `fix/eval-local-export-leak` work — this does not depend on it.
- The internal engine kwarg is untouched: `Evaluation._kwargs()` still passes `data=self.dataset` into the private `_run_async()` engine call (`evaluation.py:87`). That is the engine's own parameter name, not part of the public `evaluate()` surface, and is intentionally left as-is.
- Follow-up (owned by docs PR #1924): `docs/evals/running-evals.mdx` still carries the alias sentence and needs it dropped. Not included here.

## Test plan

- [x] `py_compile` on `traceroot/eval/evaluation.py` is clean
- [x] `evaluate()` / `evaluate_async()` signatures verified from branch source — `data` absent, `dataset` required with no default
- [x] No lingering `_resolve_dataset` references anywhere in source or tests
- [x] No public `data=` alias parameter remains (the sole remaining `data=self.dataset` is the private engine kwarg, unchanged by design)
- [ ] Docs alias sentence in `running-evals.mdx` dropped (follow-up, docs PR #1924)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the `data` alias from `evaluate()`/`evaluate_async` and makes `dataset` required to remove ambiguous resolution and align with `Evaluation`. Previously both were accepted with `dataset` silently winning; now only `dataset` is allowed and omitting it is a call-site type error.

- Migration
  - Replace all uses of data= with dataset= in `evaluate()` and `evaluate_async`.
  - Always pass a `Dataset`, `DatasetSnapshot`, or list of cases via dataset. Inline lists must run with local=True to avoid reporting.

- Review notes
  - Remove `_resolve_dataset`; both functions accept `dataset: DataSource` and pass it directly to `Evaluation`.
  - Keep the internal engine kwarg as `data=self.dataset`; the public API is `dataset` only.
  - No deprecation window.
  - Tests updated to use dataset= and to assert TypeError when data= is passed.

<sup>Written for commit 9f2ad3a0f4b624a44c442f8330600fdbff75f063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

