### PR TITLE
fix(eval): origin-scope the local=True export gate (mark-at-start, drop-at-end)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
     "opentelemetry-api>=1.34.0,<2.0",
     "opentelemetry-sdk>=1.34.0,<2.0",
     "opentelemetry-exporter-otlp-proto-http>=1.34.0,<2.0",
+    # is_instrumentation_enabled(): the public reader for OTel's tracing-suppression
+    # flag, which the local=True eval gate keys on. Already present transitively via
+    # every openinference-instrumentation-* package; declared because we import it.
+    "opentelemetry-instrumentation>=0.46b0",
     "openinference-instrumentation>=0.1.40,<1.0",
     "openinference-instrumentation-agno>=0.1.29,<1.0",
     "openinference-instrumentation-groq>=0.1.13,<1.0",

--- a/tests/eval/test_local_flag.py
+++ b/tests/eval/test_local_flag.py
@@ -419,26 +419,26 @@ class TestLocalSuppressesGlobalAutoInit:
         finally:
             reported_proc.shutdown()
 
-    def test_span_started_in_local_run_but_ended_after_is_dropped(self, export_spy):
-        """A span BORN inside the local run whose ``on_end`` fires AFTER the run's context has
-        exited is still dropped: the decision is stamped at birth (origin), not read at end. This is
-        exactly the case the process-global gate got wrong (it exported spans that outlived the run)."""
-        from opentelemetry.sdk.trace import TracerProvider
+    def test_span_started_in_local_run_but_ended_after_is_dropped(
+        self, no_credentials, no_exfiltration, export_spy, monkeypatch
+    ):
+        """A span BORN inside the local run whose ``.end()`` fires AFTER the run has returned never
+        exports: the run samples its spans DROP at creation, so the span is non-recording for its
+        whole life and no processor ever sees it. This is the case the process-global gate got wrong
+        (it exported spans that outlived the run). Mirrors the TS test of the same name, which
+        captures a span inside the run and ends it afterwards."""
+        with _already_initialized_client(monkeypatch) as client:
+            held = []
 
-        from traceroot.transport.span_processor import (
-            TracerootSpanProcessor,
-            mark_local_eval_run,
-        )
+            def task(x):
+                # Started inside the run, deliberately NOT ended there.
+                held.append(client._provider.get_tracer("app").start_span("late.work"))
+                return x
 
-        provider = TracerProvider()
-        proc = TracerootSpanProcessor(api_key="k", host_url="https://host.invalid")
-        provider.add_span_processor(proc)
-        try:
-            with mark_local_eval_run():
-                span = provider.get_tracer("app").start_span("late.work")  # on_start stamps it
-            # The local run's context has now exited (marker reset); the span ends only now.
-            span.end()
+            evaluate(name="r", data=_dataset(), task=task, scorers=[exact], local=True)
 
-            assert "late.work" not in export_spy  # dropped despite ending after the run
-        finally:
-            proc.shutdown()
+            assert held and not held[0].is_recording()  # non-recording from birth
+            for span in held:
+                span.end()  # ends only now, after the run's context is gone
+
+            assert "late.work" not in export_spy

--- a/tests/eval/test_local_flag.py
+++ b/tests/eval/test_local_flag.py
@@ -10,6 +10,8 @@ stay observationally identical. Parity with traceroot-ts/tests/eval-local-flag.t
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import urllib.request
 
 import pytest
@@ -48,6 +50,35 @@ def echo(x):
 
 def exact(ctx):
     return 1.0 if ctx.output == ctx.expected else 0.0
+
+
+@contextlib.contextmanager
+def _already_initialized_client(monkeypatch):
+    """An app that ALREADY called ``initialize()``: a fresh, fully-initialized (enabled, exporting)
+    provider with a real OpenAI instrumentation integration -- the starting point the origin gate
+    must cover. Fake host; the export spy sits before export, so nothing touches the network.
+
+    Don't let ``initialize()`` claim OTel's process-global tracer-provider slot (set-once): the run
+    is driven through the client's own provider, and claiming the slot would poison sibling tests.
+    Yields the client; undoes the real (global) OpenAI instrumentation on exit so it can't leak onto
+    sibling tests (the rest of the suite mocks the instrumentor for this reason)."""
+    import traceroot
+    from traceroot import Integration
+
+    monkeypatch.setattr("opentelemetry.trace.set_tracer_provider", lambda *a, **k: None)
+    traceroot.shutdown()
+    traceroot._client = None
+    client = traceroot.initialize(
+        api_key="k", host_url="https://host.invalid", integrations=[Integration.OPENAI]
+    )
+    try:
+        yield client
+    finally:
+        from openinference.instrumentation.openai import OpenAIInstrumentor
+
+        OpenAIInstrumentor().uninstrument()
+        traceroot.shutdown()
+        traceroot._client = None
 
 
 def _summary(result) -> dict:
@@ -260,12 +291,12 @@ class TestLocalSuppressesGlobalAutoInit:
     an exporting provider and ship case data off-process: the lazy-init seam is suppressed for the
     whole run and released after. Parity with the TS ``_suppressGlobalAutoInit`` seam.
 
-    A ``local=True`` run also suppresses export from a provider the app ALREADY initialized: an
+    A ``local=True`` run also drops export from a provider the app ALREADY initialized: an
     ``initialize()`` call before the eval leaves a live exporting provider whose auto-instrumented
-    spans (OpenAI/Anthropic/...) would otherwise ship despite ``local=True``, so they are dropped at
-    the exporter boundary for the run's duration. That drop is currently process-global, so it also
-    over-reaches onto an unrelated concurrent reported run's spans; that known limitation is tracked
-    in traceroot-ai/traceroot#1969 (origin-scoped redesign) and pinned by the xfail below."""
+    spans (OpenAI/Anthropic/...) would otherwise ship despite ``local=True``. The drop is
+    ORIGIN-scoped (traceroot-ai/traceroot#1969): a span born inside the local run is stamped at
+    creation and dropped at the exporter boundary no matter when it ends, while a span born OUTSIDE
+    the run (e.g. a concurrent reported run) carries no stamp and exports normally."""
 
     def test_local_run_suppresses_lazy_auto_init(
         self, no_credentials, no_exfiltration, monkeypatch
@@ -309,25 +340,11 @@ class TestLocalSuppressesGlobalAutoInit:
     def test_already_initialized_provider_exports_nothing_during_local_run(
         self, no_credentials, no_exfiltration, export_spy, monkeypatch
     ):
-        """The fix: an app that already called ``initialize()`` has a live exporting provider; a
-        ``local=True`` run drops its spans at the exporter boundary for the whole run. A task span
-        named like an auto-instrumented LLM call ("messages.create"), created through that
+        """The fix (sync path): an app that already called ``initialize()`` has a live exporting
+        provider; a ``local=True`` run drops the spans it originates at the exporter boundary. A
+        task span named like an auto-instrumented LLM call ("messages.create"), created through that
         already-initialized provider, forwards NOTHING to export."""
-        import traceroot
-        from traceroot import Integration
-
-        # Fresh, fully-initialized (enabled, exporting) provider with a real instrumentation
-        # integration -- the "app already called initialize()" starting point. Fake host: the spy
-        # sits before export, so nothing touches the network regardless. Don't let initialize()
-        # claim OTel's process-global tracer-provider slot (set-once): the run is driven through
-        # the client's own provider below, and claiming the slot would poison sibling tests.
-        monkeypatch.setattr("opentelemetry.trace.set_tracer_provider", lambda *a, **k: None)
-        traceroot.shutdown()
-        traceroot._client = None
-        client = traceroot.initialize(
-            api_key="k", host_url="https://host.invalid", integrations=[Integration.OPENAI]
-        )
-        try:
+        with _already_initialized_client(monkeypatch) as client:
 
             def task(x):
                 client._provider.get_tracer("app").start_span("messages.create").end()
@@ -335,37 +352,93 @@ class TestLocalSuppressesGlobalAutoInit:
 
             evaluate(name="r", data=_dataset(), task=task, scorers=[exact], local=True)
 
-            assert export_spy == []  # nothing left the process during the local run
-        finally:
-            # Real openai instrumentation globally patches the library; undo it so it can't leak
-            # onto sibling tests (the rest of the suite mocks the instrumentor for this reason).
-            from openinference.instrumentation.openai import OpenAIInstrumentor
+            assert export_spy == []  # nothing the local run originated left the process
 
-            OpenAIInstrumentor().uninstrument()
-            traceroot.shutdown()
-            traceroot._client = None
+    async def test_already_initialized_provider_exports_nothing_during_local_run_async(
+        self, no_credentials, no_exfiltration, export_spy, monkeypatch
+    ):
+        """Same guarantee on the async entry path (``evaluate_async``): the guard rides the marker
+        contextvar into every per-case asyncio task, so the task's instrumented span is dropped."""
+        with _already_initialized_client(monkeypatch) as client:
 
-    @pytest.mark.xfail(
-        reason="over-reach: origin-scoping, traceroot-ai/traceroot#1969", strict=False
-    )
-    def test_unrelated_reported_span_still_exports_during_suppression(self, export_spy):
-        """DESIRED (post-#1969): suppression engaged for a local run must not reach an unrelated,
-        concurrently reporting provider. Today the drop is process-global, so this span is dropped
-        too -- so this xfails now and will xpass once export suppression is origin-scoped."""
+            def task(x):
+                client._provider.get_tracer("app").start_span("messages.create").end()
+                return x
+
+            await evaluate_async(name="r", data=_dataset(), task=task, scorers=[exact], local=True)
+
+            assert export_spy == []
+
+    async def test_already_initialized_provider_exports_nothing_from_worker_thread(
+        self, no_credentials, no_exfiltration, export_spy, monkeypatch
+    ):
+        """The worker-thread path: a synchronous ``evaluate(local=True)`` called from INSIDE a
+        running loop runs to completion in a worker thread (``_run`` -> ``pool.submit`` ->
+        ``asyncio.run``). The marker is (re)established inside ``_run_async`` in that worker and the
+        copied context carries it across the hop, so the task's instrumented span is still dropped."""
+        with _already_initialized_client(monkeypatch) as client:
+
+            def task(x):
+                client._provider.get_tracer("app").start_span("messages.create").end()
+                return x
+
+            # This test is async, so a loop is already running on this thread -> the worker path.
+            evaluate(name="r", data=_dataset(), task=task, scorers=[exact], local=True)
+
+            assert export_spy == []
+
+    def test_unrelated_reported_span_still_exports_during_local_run(self, export_spy):
+        """Origin-scoping (#1969): a local run being active must not reach an unrelated, concurrently
+        reporting provider. The local marker is set in one context; a reported span born in a
+        SEPARATE context (its own run) is never stamped, so it still exports -- the process-global
+        gate this replaced dropped it too."""
         from opentelemetry.sdk.trace import TracerProvider
 
         from traceroot.transport.span_processor import (
             TracerootSpanProcessor,
-            suppress_span_export,
+            mark_local_eval_run,
         )
 
         reported_provider = TracerProvider()
         reported_proc = TracerootSpanProcessor(api_key="k2", host_url="https://reported.invalid")
         reported_provider.add_span_processor(reported_proc)
+        # The reported run's context, captured independently of any local run (marker unset in it).
+        reported_ctx = contextvars.copy_context()
         try:
-            with suppress_span_export():
-                reported_provider.get_tracer("reported-app").start_span("reported.work").end()
+            with mark_local_eval_run():  # a local run is active in THIS context
+                # The reported span is born in the reported run's own context -> no stamp -> exports.
+                reported_ctx.run(
+                    lambda: (
+                        reported_provider.get_tracer("reported-app")
+                        .start_span("reported.work")
+                        .end()
+                    )
+                )
 
             assert "reported.work" in export_spy  # the unrelated reported run still exported
         finally:
             reported_proc.shutdown()
+
+    def test_span_started_in_local_run_but_ended_after_is_dropped(self, export_spy):
+        """A span BORN inside the local run whose ``on_end`` fires AFTER the run's context has
+        exited is still dropped: the decision is stamped at birth (origin), not read at end. This is
+        exactly the case the process-global gate got wrong (it exported spans that outlived the run)."""
+        from opentelemetry.sdk.trace import TracerProvider
+
+        from traceroot.transport.span_processor import (
+            TracerootSpanProcessor,
+            mark_local_eval_run,
+        )
+
+        provider = TracerProvider()
+        proc = TracerootSpanProcessor(api_key="k", host_url="https://host.invalid")
+        provider.add_span_processor(proc)
+        try:
+            with mark_local_eval_run():
+                span = provider.get_tracer("app").start_span("late.work")  # on_start stamps it
+            # The local run's context has now exited (marker reset); the span ends only now.
+            span.end()
+
+            assert "late.work" not in export_spy  # dropped despite ending after the run
+        finally:
+            proc.shutdown()

--- a/tests/eval/test_local_flag.py
+++ b/tests/eval/test_local_flag.py
@@ -391,15 +391,24 @@ class TestLocalSuppressesGlobalAutoInit:
         """Origin-scoping (#1969): a local run being active must not reach an unrelated, concurrently
         reporting provider. The local marker is set in one context; a reported span born in a
         SEPARATE context (its own run) is never stamped, so it still exports -- the process-global
-        gate this replaced dropped it too."""
+        gate this replaced dropped it too.
+
+        The reported provider's sampler is wrapped with ``LocalEvalSampler`` -- exactly what
+        ``TracerootClient`` does in ``client.py`` -- so this test actually exercises the real gate.
+        A bare ``TracerProvider()``'s default sampler never consults the suppression flag at all, so
+        without this wrapping the assertion below would pass unconditionally, whether the gate is
+        correctly context-scoped or regressed to process-global: it would never observe the
+        difference either way."""
         from opentelemetry.sdk.trace import TracerProvider
 
         from traceroot.transport.span_processor import (
+            LocalEvalSampler,
             TracerootSpanProcessor,
             mark_local_eval_run,
         )
 
         reported_provider = TracerProvider()
+        reported_provider.sampler = LocalEvalSampler(reported_provider.sampler)
         reported_proc = TracerootSpanProcessor(api_key="k2", host_url="https://reported.invalid")
         reported_provider.add_span_processor(reported_proc)
         # The reported run's context, captured independently of any local run (marker unset in it).

--- a/traceroot/client.py
+++ b/traceroot/client.py
@@ -29,7 +29,7 @@ from traceroot.git_context import (
     harvest_ci_git_context,
 )
 from traceroot.instrumentation.registry import Integration
-from traceroot.transport.span_processor import TracerootSpanProcessor
+from traceroot.transport.span_processor import LocalEvalSampler, TracerootSpanProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -167,8 +167,11 @@ class TracerootClient:
             git_ref=self.git_ref,
         )
 
-        # Create and configure TracerProvider
+        # Create and configure TracerProvider. Wrap whatever sampler the SDK resolved (default, or
+        # OTEL_TRACES_SAMPLER) so a local=True eval run samples its own spans DROP -- they are never
+        # recorded, so they cannot be exported by this or any other processor on the provider.
         self._provider = TracerProvider()
+        self._provider.sampler = LocalEvalSampler(self._provider.sampler)
         self._provider.add_span_processor(self._span_processor)
 
         # Set as global provider so @observe decorator uses it

--- a/traceroot/eval/engine.py
+++ b/traceroot/eval/engine.py
@@ -740,7 +740,21 @@ def _to_snapshot(
     )
 
 
-async def _run_async(
+async def _run_async(**kwargs: Any) -> EvalRunResult:
+    """Core async runner and the single chokepoint for the local export guard.
+
+    Every entry path funnels through here -- ``_run`` (sync, via ``asyncio.run`` on this thread or a
+    worker thread) and ``Evaluation.run_async`` (direct ``await``) -- so applying the ``local=True``
+    guard here covers all of them. The guard sets the origin marker in THIS coroutine's context;
+    per-case asyncio tasks copy it automatically and sync tasks copy it into their thread-pool
+    worker, so every span the run originates is stamped and dropped. Reported runs pass straight
+    through. See ``_run_async_inner`` for the body.
+    """
+    with _local_run_guards(bool(kwargs.get("local"))):
+        return await _run_async_inner(**kwargs)
+
+
+async def _run_async_inner(
     *,
     name: str,
     data: Dataset | DatasetSnapshot | Sequence[EvalCase | dict],
@@ -761,7 +775,7 @@ async def _run_async(
     on_case_complete: Callable[[EvalItemResult, float], None] | None = None,
     on_run_start: Callable[[str, str | None], None] | None = None,
 ) -> EvalRunResult:
-    """Core async runner. Public entry is ``evaluate``/``Evaluation`` (evaluation.py).
+    """Core async runner body. Public entry is ``evaluate``/``Evaluation`` (evaluation.py).
 
     ``timeout`` bounds each task (seconds; a timeout is an isolated per-case error).
     ``local`` runs fully but reports nowhere (see the transport block below).
@@ -1044,33 +1058,39 @@ async def _run_async(
 
 @contextlib.contextmanager
 def _local_run_guards(local: bool):
-    """Guards a ``local=True`` run so NOTHING leaves the process for its duration.
+    """Guards a ``local=True`` run so NOTHING it originates leaves the process for its duration.
 
-    Two independent leaks have to be closed together:
+    Two independent leaks are closed together:
     - ``_suppress_global_auto_init``: a task/judge ``@observe`` (or lazy auto-instrumentation)
       must not bring up an exporting provider mid-run.
-    - ``suppress_span_export``: an app that ALREADY called ``initialize()`` has a live exporting
-      provider; its auto-instrumented library spans (OpenAI/Anthropic/...) flow through the global
-      provider and would otherwise be exported despite ``local=True``. Drop them for the run.
+    - ``mark_local_eval_run``: an app that ALREADY called ``initialize()`` has a live exporting
+      provider; the library spans its task creates (OpenAI/Anthropic/...) flow through it. They are
+      ORIGIN-stamped at creation and dropped at the exporter boundary, so nothing this run
+      originates is exported -- while a concurrent *reported* run's spans, born outside this
+      context, still export. Applied at the ``_run_async`` chokepoint, so the marker rides the
+      contextvar into every per-case asyncio task and thread-pool worker.
     Reported (non-local) runs are unaffected. Mirrors the TS SDK's local guards.
     """
     if not local:
         yield
         return
     from traceroot.decorators import _suppress_global_auto_init
-    from traceroot.transport.span_processor import suppress_span_export
+    from traceroot.transport.span_processor import mark_local_eval_run
 
-    with _suppress_global_auto_init(), suppress_span_export():
+    with _suppress_global_auto_init(), mark_local_eval_run():
         yield
 
 
 def _run(**kwargs: Any) -> EvalRunResult:
     """Synchronous core runner. Always returns a completed EvalRunResult."""
-    with _local_run_guards(bool(kwargs.get("local"))):
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return asyncio.run(_run_async(**kwargs))
-        # A loop is already running in this thread: run to completion in a worker thread.
-        with ThreadPoolExecutor(max_workers=1) as pool:
-            return pool.submit(lambda: asyncio.run(_run_async(**kwargs))).result()
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_run_async(**kwargs))
+    # A loop is already running in this thread: run to completion in a worker thread. A bare
+    # ThreadPoolExecutor.submit drops the caller's contextvars, so run the work through a copy of
+    # the current context -- the local-eval marker (set inside _run_async) and any active parent
+    # context then survive the thread hop instead of starting from a blank context.
+    ctx = contextvars.copy_context()
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(lambda: ctx.run(lambda: asyncio.run(_run_async(**kwargs)))).result()

--- a/traceroot/eval/evaluation.py
+++ b/traceroot/eval/evaluation.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from typing import Any
 
-from traceroot.eval.engine import _LOCAL_AND_TRANSPORT, _local_run_guards, _run, _run_async
+from traceroot.eval.engine import _LOCAL_AND_TRANSPORT, _run, _run_async
 from traceroot.eval.results import EvalRunResult
 from traceroot.eval.transport import EvalTransport
 from traceroot.eval.types import Dataset, DatasetSnapshot, EvalCase, ScorerContext
@@ -106,12 +106,9 @@ class Evaluation:
         return _run(**self._kwargs(overrides))
 
     async def run_async(self, **overrides: Any) -> EvalRunResult:
-        # _run (sync) applies the local guards itself; the async path calls _run_async directly,
-        # so apply them here too — otherwise a local=True run via evaluate_async()/run_async()
-        # would still export auto-instrumented spans through an already-initialized provider.
-        kwargs = self._kwargs(overrides)
-        with _local_run_guards(bool(kwargs.get("local"))):
-            return await _run_async(**kwargs)
+        # _run_async is the single chokepoint that applies the local=True export guard, so both the
+        # sync (_run) and async paths inherit it -- nothing to do here beyond the direct await.
+        return await _run_async(**self._kwargs(overrides))
 
 
 def _resolve_dataset(dataset: DataSource | None, data: DataSource | None) -> DataSource:

--- a/traceroot/transport/span_processor.py
+++ b/traceroot/transport/span_processor.py
@@ -4,19 +4,20 @@ This module defines the TracerootSpanProcessor class, which extends
 OpenTelemetry's BatchSpanProcessor with Traceroot-specific configuration.
 """
 
-import contextvars
 import logging
 import os
 import threading
 from collections import OrderedDict
-from contextlib import contextmanager
 
+from openinference.instrumentation import suppress_tracing
 from opentelemetry import trace as otel_trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     Compression,
     OTLPSpanExporter,
 )
+from opentelemetry.instrumentation.utils import is_instrumentation_enabled
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
 
 from traceroot.constants import (
     DEFAULT_FLUSH_AT,
@@ -36,44 +37,74 @@ logger = logging.getLogger(__name__)
 _PATH_MAP_MAX: int = 1024
 _PathMap = OrderedDict[str, list[str]]
 
-# --- Origin-scoped local-eval export gate --------------------------------------
-# A local=True eval run must not let its OWN instrumented spans leave the process, even when the app
-# already called initialize() and has a live exporting provider (auto-instrumented OpenAI/Anthropic
-# /... spans flow through it and would otherwise export despite local=True). _suppress_global_auto_init
-# only stops a *lazy* provider from coming up; it cannot stop an *already-initialized* one -- this
-# gate is the other half.
+# --- Local-eval gate: OTel's own tracing-suppression flag, enforced at span CREATION -------------
+# A local=True eval run must not let the spans it originates leave the process, even when the app
+# already called initialize() and has a live exporting provider. _suppress_global_auto_init only
+# stops a *lazy* provider coming up; it cannot stop an already-initialized one -- this is the
+# other half.
 #
-# The gate is ORIGIN-scoped: the decision to drop is made from WHERE a span came from, marked at
-# creation, not from WHEN it ends. A ContextVar records "inside a local eval run" (the engine sets
-# it for the run's duration; it follows asyncio tasks and any worker whose context is copied in). In
-# on_start, if the var is set, the span is STAMPED; in on_end, any stamped span is dropped. This
-# fixes the process-global gate's two failures: a concurrent *reported* run's spans (born outside
-# the marked context) still export, and a span born inside the run but ending after it still drops.
+# The marker is OpenTelemetry's own tracing-suppression context flag -- the exact mechanism the TS
+# SDK uses (context.with(suppressTracing(...))) and the one the instrumentation ecosystem already
+# honours. Setting it buys two things:
+#   1. every OpenInference instrumentor short-circuits in its own tracer and returns INVALID_SPAN,
+#      so an instrumented LLM/tool span is never even built (no attribute work at all); and
+#   2. LocalEvalSampler below returns DROP for anything else, so a raw tracer.start_span() -- which
+#      no instrumentor mediates -- is non-recording too.
 #
-# The stamp is a span ATTRIBUTE rather than a side-table of span-ids: it rides with the span, so a
-# span that ends long after the run's context has exited is still recognized (no lifetime bound, no
-# eviction race, trivially correct for late-ending spans). It is visible to other span processors on
-# the same provider, which is acceptable -- a span marked for a local eval run is never exported.
-_LOCAL_EVAL_SPAN_ATTR = "traceroot.eval.local_only"
+# Step 2 exists only because OTel-Python's SDK does not consult the flag in Tracer.start_span the
+# way OTel-JS does (its _is_enabled() checks the per-scope tracer configurator and nothing else), so
+# the sampler is the shim that teaches the Python SDK to honour the same flag. Both SDKs therefore
+# set the same kind of marker and get the same result: a span born inside a local run is
+# non-recording, never reaches a span processor, and cannot be exported -- whenever it ends. This is
+# the principle every local-mode implementation we surveyed converges on: suppress where the span is
+# BORN, not where it is sent.
+#
+# The flag is read through opentelemetry-instrumentation's public is_instrumentation_enabled(), so no
+# private OTel constant sits in the guarantee path, and both the current and legacy key spellings are
+# covered. It reads the AMBIENT context, which is what we want: the engine sets the flag ambiently for
+# the run, so a caller passing an explicit parent Context (as the engine does for its per-case roots)
+# cannot step around the gate. Same ambient read OpenInference's own tracer does.
 
-_in_local_eval_run: contextvars.ContextVar[bool] = contextvars.ContextVar(
-    "traceroot_in_local_eval_run", default=False
-)
 
-
-@contextmanager
 def mark_local_eval_run():
-    """Mark the current context as inside a ``local=True`` eval run.
+    """Suppress tracing for the current context for the duration of a ``local=True`` eval run.
 
-    Spans STARTED while this is active are stamped so ``on_end`` drops them instead of exporting.
-    Token-based set/reset so nested or concurrent runs restore the exact prior state. Reported
-    (non-local) runs never enter here, so their spans are never stamped and export normally.
+    Returns OpenInference's ``suppress_tracing`` context manager, which sets OTel's tracing
+    suppression flag -- the Python counterpart of the TS SDK's ``suppressTracing(context.active())``.
+    Context-scoped, so it follows asyncio tasks and any worker whose context is copied in, and a
+    concurrent *reported* run in its own context is untouched.
     """
-    token = _in_local_eval_run.set(True)
-    try:
-        yield
-    finally:
-        _in_local_eval_run.reset(token)
+    return suppress_tracing()
+
+
+class LocalEvalSampler(Sampler):
+    """Makes OTel-Python honour the tracing-suppression flag that OTel-JS honours natively.
+
+    Delegates to the provider's real sampler unless tracing is suppressed for this context, in
+    which case the span is DROPped and OTel returns a NonRecordingSpan.
+    """
+
+    def __init__(self, inner: Sampler):
+        self._inner = inner
+
+    def should_sample(
+        self,
+        parent_context=None,
+        trace_id=0,
+        name="",
+        kind=None,
+        attributes=None,
+        links=None,
+        trace_state=None,
+    ) -> SamplingResult:
+        if not is_instrumentation_enabled():
+            return SamplingResult(Decision.DROP, None, trace_state)
+        return self._inner.should_sample(
+            parent_context, trace_id, name, kind, attributes, links, trace_state
+        )
+
+    def get_description(self) -> str:
+        return f"LocalEvalSampler({self._inner.get_description()})"
 
 
 class TracerootSpanProcessor(BatchSpanProcessor):
@@ -173,10 +204,6 @@ class TracerootSpanProcessor(BatchSpanProcessor):
 
     def on_start(self, span, parent_context=None):
         if span.is_recording():
-            # ORIGIN gate: a span born inside a local=True eval run is stamped at creation so that
-            # on_end can drop it regardless of when (or in what context) it ends.
-            if _in_local_eval_run.get():
-                span.set_attribute(_LOCAL_EVAL_SPAN_ATTR, True)
             span.set_attribute("traceroot.sdk.name", SDK_NAME)
             span.set_attribute("traceroot.sdk.version", SDK_VERSION)
             if self._git_repo:
@@ -262,13 +289,6 @@ class TracerootSpanProcessor(BatchSpanProcessor):
             span_id_hex = format(span.context.span_id, "016x")
             self._ids_path_by_span_id.pop(span_id_hex, None)
             self._name_path_by_span_id.pop(span_id_hex, None)
-        attrs = getattr(span, "attributes", None)
-        if attrs is not None and attrs.get(_LOCAL_EVAL_SPAN_ATTR):
-            # Born inside a local=True eval run (stamped at on_start): drop it instead of queueing
-            # for export, so nothing the run originates leaves the process -- even if it ends after
-            # the run's context has exited. Spans born outside that context (e.g. a concurrent
-            # reported run) carry no stamp and export normally.
-            return
         super().on_end(span)
 
     @property

--- a/traceroot/transport/span_processor.py
+++ b/traceroot/transport/span_processor.py
@@ -4,6 +4,7 @@ This module defines the TracerootSpanProcessor class, which extends
 OpenTelemetry's BatchSpanProcessor with Traceroot-specific configuration.
 """
 
+import contextvars
 import logging
 import os
 import threading
@@ -35,33 +36,44 @@ logger = logging.getLogger(__name__)
 _PATH_MAP_MAX: int = 1024
 _PathMap = OrderedDict[str, list[str]]
 
-# --- Scoped export suppression -------------------------------------------------
-# When active, TracerootSpanProcessor.on_end DROPS the span instead of queueing it for export.
-# A local=True eval run turns this on for its whole duration so that an app which already called
-# initialize() exports NOTHING during the run -- including auto-instrumented library spans
-# (OpenAI/Anthropic/...), which flow through the global provider and would otherwise leak. This is
-# the missing half of the local-only guarantee: _suppress_global_auto_init only stops a *lazy*
-# provider from coming up; it cannot stop an *already-initialized* exporting provider. Process-global
-# and reentrant (a depth counter), so it survives concurrent cases and nested runs.
-_export_suppress_depth: int = 0
-_export_suppress_lock = threading.Lock()
+# --- Origin-scoped local-eval export gate --------------------------------------
+# A local=True eval run must not let its OWN instrumented spans leave the process, even when the app
+# already called initialize() and has a live exporting provider (auto-instrumented OpenAI/Anthropic
+# /... spans flow through it and would otherwise export despite local=True). _suppress_global_auto_init
+# only stops a *lazy* provider from coming up; it cannot stop an *already-initialized* one -- this
+# gate is the other half.
+#
+# The gate is ORIGIN-scoped: the decision to drop is made from WHERE a span came from, marked at
+# creation, not from WHEN it ends. A ContextVar records "inside a local eval run" (the engine sets
+# it for the run's duration; it follows asyncio tasks and any worker whose context is copied in). In
+# on_start, if the var is set, the span is STAMPED; in on_end, any stamped span is dropped. This
+# fixes the process-global gate's two failures: a concurrent *reported* run's spans (born outside
+# the marked context) still export, and a span born inside the run but ending after it still drops.
+#
+# The stamp is a span ATTRIBUTE rather than a side-table of span-ids: it rides with the span, so a
+# span that ends long after the run's context has exited is still recognized (no lifetime bound, no
+# eviction race, trivially correct for late-ending spans). It is visible to other span processors on
+# the same provider, which is acceptable -- a span marked for a local eval run is never exported.
+_LOCAL_EVAL_SPAN_ATTR = "traceroot.eval.local_only"
 
-
-def _is_export_suppressed() -> bool:
-    return _export_suppress_depth > 0
+_in_local_eval_run: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "traceroot_in_local_eval_run", default=False
+)
 
 
 @contextmanager
-def suppress_span_export():
-    """Drop every TracerootSpanProcessor export for the duration of the block."""
-    global _export_suppress_depth
-    with _export_suppress_lock:
-        _export_suppress_depth += 1
+def mark_local_eval_run():
+    """Mark the current context as inside a ``local=True`` eval run.
+
+    Spans STARTED while this is active are stamped so ``on_end`` drops them instead of exporting.
+    Token-based set/reset so nested or concurrent runs restore the exact prior state. Reported
+    (non-local) runs never enter here, so their spans are never stamped and export normally.
+    """
+    token = _in_local_eval_run.set(True)
     try:
         yield
     finally:
-        with _export_suppress_lock:
-            _export_suppress_depth -= 1
+        _in_local_eval_run.reset(token)
 
 
 class TracerootSpanProcessor(BatchSpanProcessor):
@@ -161,6 +173,10 @@ class TracerootSpanProcessor(BatchSpanProcessor):
 
     def on_start(self, span, parent_context=None):
         if span.is_recording():
+            # ORIGIN gate: a span born inside a local=True eval run is stamped at creation so that
+            # on_end can drop it regardless of when (or in what context) it ends.
+            if _in_local_eval_run.get():
+                span.set_attribute(_LOCAL_EVAL_SPAN_ATTR, True)
             span.set_attribute("traceroot.sdk.name", SDK_NAME)
             span.set_attribute("traceroot.sdk.version", SDK_VERSION)
             if self._git_repo:
@@ -246,9 +262,12 @@ class TracerootSpanProcessor(BatchSpanProcessor):
             span_id_hex = format(span.context.span_id, "016x")
             self._ids_path_by_span_id.pop(span_id_hex, None)
             self._name_path_by_span_id.pop(span_id_hex, None)
-        if _is_export_suppressed():
-            # A local=True eval run is in progress: drop the span instead of queueing it for
-            # export, so nothing (including auto-instrumented spans) leaves the process.
+        attrs = getattr(span, "attributes", None)
+        if attrs is not None and attrs.get(_LOCAL_EVAL_SPAN_ATTR):
+            # Born inside a local=True eval run (stamped at on_start): drop it instead of queueing
+            # for export, so nothing the run originates leaves the process -- even if it ends after
+            # the run's context has exited. Spans born outside that context (e.g. a concurrent
+            # reported run) carry no stamp and export normally.
             return
         super().on_end(span)
 


### PR DESCRIPTION
## Summary
Fixes: traceroot-ai/traceroot#1969

A `local=True` eval run promises that nothing it produces leaves the process. The shipped guarantee was enforced by a process-global export gate that decided by WHEN a span ended: while a local run was active, `on_end` dropped every span passing through any `TracerootSpanProcessor`. That gate had two failures — it over-reached onto a concurrent *reported* run's spans (they were dropped too), and it leaked a span born inside the local run whose `on_end` fired after the run's context had exited (the gate was no longer active).

This PR replaces that gate with an ORIGIN-scoped one: the decision to drop is made from WHERE a span came from, marked at creation, instead of from when it ends. A `contextvars.ContextVar` records "inside a local eval run" for the run's duration; `on_start` stamps a span attribute `traceroot.eval.local_only` when that marker is set, and `on_end` drops any stamped span. A span born inside the run is therefore dropped no matter when (or in what context) it ends, while a span born outside the marked context — a concurrent reported run — carries no stamp and exports normally.

The stamp is a span attribute rather than a side-table of span-ids on purpose: it rides with the span, so a span that ends long after the run's context has exited is still recognized with no lifetime bound and no eviction race — trivially correct for late-ending spans.

This is the Python half of a cross-SDK parity fix; the same origin-scoping principle lands in traceroot-ts. TS uses OTel-JS's native `suppressTracing` (spans are never created), while Python uses mark-at-start / predicate-at-end because OTel-Python's `start_span` does not honour the suppression context key.

## What changed
`traceroot/transport/span_processor.py` — deletes the process-global counter machinery (`_export_suppress_depth`, `_export_suppress_lock`, `_is_export_suppressed`, `suppress_span_export`) and replaces it with a `contextvars.ContextVar` marker plus a `mark_local_eval_run()` context manager (token-based set/reset so nested and concurrent runs restore the exact prior state). `on_start` stamps `traceroot.eval.local_only` when the marker is set; `on_end` drops any span carrying that attribute.

`traceroot/eval/engine.py` — moves the guard to the single `_run_async` chokepoint that every entry path funnels through. `_run_async` is now a thin wrapper that applies `_local_run_guards` around a new `_run_async_inner` body, so `_run` (sync / worker-thread) and `Evaluation.run_async` (direct await) all inherit the guard. `_local_run_guards` now composes `_suppress_global_auto_init` with `mark_local_eval_run` instead of `suppress_span_export`. In `_run`, the worker-thread `pool.submit` is wrapped in `contextvars.copy_context().run(...)` so the marker (and any active parent span context) survives the thread hop instead of starting from a blank context.

`traceroot/eval/evaluation.py` — reverts `run_async` to a plain `await _run_async(...)` with no local guard of its own, since the guard now lives at the `_run_async` chokepoint; drops the now-unused `_local_run_guards` import.

`tests/eval/test_local_flag.py` — factors the "app already called initialize()" setup into a shared `_already_initialized_client` fixture; adds sync / async / worker-thread coverage that an instrumented span is dropped; turns the previously-`xfail` "concurrent reported run still exports" assertion into a passing test (reported span born in a separately-copied context); adds a "span started inside the run, ended after it" test proving the late-ending case now drops.

Both SDKs keep `_suppress_global_auto_init` (still needed for the lazy-init case, where no exporting provider exists yet) and leave the CLI `_enforce_local_only()` untouched.

## Stacking
This branch is stacked on `fix/eval-local-export-leak` (PRs traceroot-py #165 / traceroot-ts #141), which shipped the process-global gate. It should merge AFTER that PR, or be rebased onto `main` once it lands; the meaningful diff is the redesign delta described above (branch vs its base).

## Test plan
- [x] Instrumented span dropped during a `local=True` run — sync path (`evaluate`)
- [x] Instrumented span dropped during a `local=True` run — async path (`evaluate_async`)
- [x] Instrumented span dropped when `evaluate(local=True)` runs in a worker thread (called from inside a running loop)
- [x] Late-finishing span (born inside the run, `on_end` after the context exits) is dropped
- [x] Concurrent *reported* run's spans still export (the previously-`xfail` assertion now passes)
- [x] `pytest tests/eval/test_local_flag.py` — 17 passed
- [x] `pytest tests/eval` — 625 passed
- [x] `pytest` (full suite) — 817 passed
- [x] `ruff check` + `ruff format --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Origin-scopes the local=True export gate by suppressing tracing at span creation. Previously a process-global export-time drop over-reached to concurrent reported runs and leaked late-ending/large spans; now spans born in a local run are non-recording, while concurrent reported runs export normally.

- Apply the guard at the `_run_async` chokepoint via `mark_local_eval_run()`. The context marker flows to per-case asyncio tasks and the worker-thread path (context copied); `Evaluation.run_async` now delegates directly.
- Replace export-time dropping with creation-time suppression:
  - Add `LocalEvalSampler` that returns DROP when suppression is active; wrap the provider sampler in `client._initialize`.
  - Remove the processor drop path; `TracerootSpanProcessor.on_end` no longer filters.
- Declare `opentelemetry-instrumentation` for `is_instrumentation_enabled()`; set the flag via OpenInference’s `suppress_tracing()`.
- Tests cover sync/async/worker-thread paths, late-ending spans staying non-recording, and a concurrent reported run exporting. Strengthen the last by wrapping the reported provider’s sampler with `LocalEvalSampler` to exercise the real gate.
- Migration: remove `suppress_span_export`; use `mark_local_eval_run()` if you referenced it.

<sup>Written for commit 09193b564999b1c9863f87ff47fee9c0848b919a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

