### PR TITLE
feat: emit ancestor span start times

### DIFF
--- a/tests/test_span_processor_path.py
+++ b/tests/test_span_processor_path.py
@@ -3,6 +3,7 @@
 Covers:
   - traceroot.span.path set correctly for root / child / deeply nested spans
   - traceroot.span.ids_path set correctly at every depth
+  - traceroot.span.starts_path carries index-aligned ancestor start times
   - Map-based ancestry lets children inherit full paths even when the parent is
     a NonRecordingSpan (the OpenInference / LangGraph pattern)
   - Map entries are cleaned up on span end (no memory leak)
@@ -49,6 +50,11 @@ def _path(span) -> list[str]:
 
 def _ids(span) -> list[str]:
     return list(span.attributes.get("traceroot.span.ids_path", ()))
+
+
+def _starts(span) -> list[str]:
+    assert "traceroot.span.starts_path" in span.attributes
+    return list(span.attributes["traceroot.span.starts_path"])
 
 
 def _hex(span_id: int) -> str:
@@ -120,6 +126,61 @@ def test_grandchild_ids_path_is_root_then_mid(proc_setup):
     assert _ids(leaf) == [root_id, mid_id]
 
 
+# ── span.starts_path propagation ──────────────────────────────────────────────
+
+
+def test_root_span_starts_path_is_present_and_empty(proc_setup):
+    tracer, exporter, _ = proc_setup
+    with tracer.start_as_current_span("root"):
+        pass
+
+    root = exporter.get_finished_spans()[0]
+    assert _starts(root) == []
+
+
+def test_nested_starts_path_matches_exported_ancestor_start_times(proc_setup):
+    tracer, exporter, _ = proc_setup
+    with (
+        tracer.start_as_current_span("root"),
+        tracer.start_as_current_span("mid"),
+        tracer.start_as_current_span("leaf"),
+    ):
+        pass
+
+    finished = {span.name: span for span in exporter.get_finished_spans()}
+    root = finished["root"]
+    mid = finished["mid"]
+    leaf = finished["leaf"]
+
+    assert _starts(root) == []
+    assert _starts(mid) == [str(root.start_time)]
+    assert _starts(leaf) == [str(root.start_time), str(mid.start_time)]
+    for span in finished.values():
+        starts_path = _starts(span)
+        assert len(starts_path) == len(_ids(span))
+        assert all(value.isascii() and value.isdecimal() for value in starts_path)
+
+
+def test_starts_path_falls_back_to_recording_parent_attributes(proc_setup):
+    tracer, exporter, processor = proc_setup
+
+    with tracer.start_as_current_span("root") as root:
+        root_id = _hex(root.context.span_id)
+        # Force the attribute-read fallback while the recording parent remains
+        # available in the explicit parent context.
+        processor._ids_path_by_span_id.pop(root_id)
+        processor._name_path_by_span_id.pop(root_id)
+        processor._starts_path_by_span_id.pop(root_id)
+        parent_context = trace.set_span_in_context(root)
+        child = tracer.start_span("child", context=parent_context)
+        child.end()
+
+    finished = {span.name: span for span in exporter.get_finished_spans()}
+    assert _ids(finished["child"]) == [root_id]
+    assert _path(finished["child"]) == ["root", "child"]
+    assert _starts(finished["child"]) == [str(finished["root"].start_time)]
+
+
 # ── Map-based ancestry (NonRecordingSpan / remote parent) ─────────────────────
 #
 # OpenInference instruments LangGraph nodes by creating spans whose parent is
@@ -152,10 +213,38 @@ def test_child_inherits_full_ids_path_via_map_when_parent_is_non_recording(proc_
             leaf = tracer.start_span("leaf", context=ctx_with_remote)
             leaf.end()
 
-    leaf_span = next(s for s in exporter.get_finished_spans() if s.name == "leaf")
+    finished = {span.name: span for span in exporter.get_finished_spans()}
+    leaf_span = finished["leaf"]
     # Without the map fix this would be [mid_id] only — root ancestry lost.
     assert _ids(leaf_span) == [root_id, mid_id]
     assert _path(leaf_span) == ["root", "mid", "leaf"]
+    assert _starts(leaf_span) == [
+        str(finished["root"].start_time),
+        str(finished["mid"].start_time),
+    ]
+
+
+def test_misaligned_starts_state_emits_empty_path(proc_setup):
+    tracer, exporter, processor = proc_setup
+
+    with tracer.start_as_current_span("root") as root:
+        root_id = _hex(root.context.span_id)
+        # Simulate dropped/corrupted timing state. The NonRecordingSpan parent
+        # prevents attribute fallback, so on_start must reject this partial chain.
+        processor._starts_path_by_span_id[root_id] = []
+        remote_ctx = SpanContext(
+            trace_id=root.context.trace_id,
+            span_id=root.context.span_id,
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        remote_parent = trace.set_span_in_context(NonRecordingSpan(remote_ctx))
+        child = tracer.start_span("child", context=remote_parent)
+        child.end()
+
+    child_span = next(span for span in exporter.get_finished_spans() if span.name == "child")
+    assert _ids(child_span) == [root_id]
+    assert _starts(child_span) == []
 
 
 def test_path_fully_inherited_via_map_for_remote_parent(proc_setup):
@@ -216,9 +305,11 @@ def test_map_entries_removed_after_span_ends(proc_setup):
     with tracer.start_as_current_span("root") as root:
         root_hex = _hex(root.context.span_id)
         assert root_hex in processor._ids_path_by_span_id
+        assert root_hex in processor._starts_path_by_span_id
 
     assert root_hex not in processor._ids_path_by_span_id
     assert root_hex not in processor._name_path_by_span_id
+    assert root_hex not in processor._starts_path_by_span_id
 
 
 def test_map_cleaned_up_for_all_spans_in_hierarchy(proc_setup):
@@ -231,35 +322,37 @@ def test_map_cleaned_up_for_all_spans_in_hierarchy(proc_setup):
         child_hex = _hex(child.context.span_id)
         assert root_hex in processor._ids_path_by_span_id
         assert child_hex in processor._ids_path_by_span_id
+        assert root_hex in processor._starts_path_by_span_id
+        assert child_hex in processor._starts_path_by_span_id
 
     assert root_hex not in processor._ids_path_by_span_id
     assert child_hex not in processor._ids_path_by_span_id
+    assert root_hex not in processor._starts_path_by_span_id
+    assert child_hex not in processor._starts_path_by_span_id
 
 
-def test_map_bounded_eviction_at_capacity(proc_setup):
-    from traceroot.transport.span_processor import _PATH_MAP_MAX
+def test_map_bounded_eviction_and_cleanup_use_real_processor_paths(proc_setup, monkeypatch):
+    import traceroot.transport.span_processor as span_processor_module
 
-    _, _, processor = proc_setup
-    # Fill map to capacity by directly inserting entries.
-    for i in range(_PATH_MAP_MAX):
-        key = format(i, "016x")
-        processor._ids_path_by_span_id[key] = []
-        processor._name_path_by_span_id[key] = []
+    tracer, _, processor = proc_setup
+    monkeypatch.setattr(span_processor_module, "_PATH_MAP_MAX", 2)
 
-    first_key = format(0, "016x")
-    assert first_key in processor._ids_path_by_span_id
+    spans = [tracer.start_span(f"span-{index}") for index in range(3)]
+    span_ids = [_hex(span.context.span_id) for span in spans]
 
-    # One more insertion should evict the oldest (first) entry.
-    overflow_key = format(_PATH_MAP_MAX, "016x")
-    if len(processor._ids_path_by_span_id) >= _PATH_MAP_MAX:
-        processor._ids_path_by_span_id.popitem(last=False)
-        processor._name_path_by_span_id.popitem(last=False)
-    processor._ids_path_by_span_id[overflow_key] = []
-    processor._name_path_by_span_id[overflow_key] = []
+    assert span_ids[0] not in processor._ids_path_by_span_id
+    assert span_ids[0] not in processor._name_path_by_span_id
+    assert span_ids[0] not in processor._starts_path_by_span_id
+    assert list(processor._ids_path_by_span_id) == span_ids[1:]
+    assert list(processor._name_path_by_span_id) == span_ids[1:]
+    assert list(processor._starts_path_by_span_id) == span_ids[1:]
 
-    assert first_key not in processor._ids_path_by_span_id
-    assert overflow_key in processor._ids_path_by_span_id
-    assert len(processor._ids_path_by_span_id) == _PATH_MAP_MAX
+    for span in spans:
+        span.end()
+
+    assert processor._ids_path_by_span_id == {}
+    assert processor._name_path_by_span_id == {}
+    assert processor._starts_path_by_span_id == {}
 
 
 # ── SDK attributes ─────────────────────────────────────────────────────────────
@@ -319,6 +412,7 @@ def test_non_recording_span_not_added_to_map(proc_setup):
     span_hex = _hex(remote_ctx.span_id)
     assert span_hex not in processor._ids_path_by_span_id
     assert span_hex not in processor._name_path_by_span_id
+    assert span_hex not in processor._starts_path_by_span_id
 
 
 def test_non_recording_span_has_no_path_attributes(proc_setup):
@@ -337,6 +431,7 @@ def test_non_recording_span_has_no_path_attributes(proc_setup):
     span_hex = _hex(remote_ctx.span_id)
     assert span_hex not in processor._ids_path_by_span_id
     assert span_hex not in processor._name_path_by_span_id
+    assert span_hex not in processor._starts_path_by_span_id
 
 
 def test_map_stays_empty_when_only_non_recording_spans_processed(proc_setup):
@@ -352,6 +447,7 @@ def test_map_stays_empty_when_only_non_recording_spans_processed(proc_setup):
 
     assert processor._ids_path_by_span_id == {}
     assert processor._name_path_by_span_id == {}
+    assert processor._starts_path_by_span_id == {}
 
 
 # ── Git context attributes ─────────────────────────────────────────────────────

--- a/traceroot/transport/span_processor.py
+++ b/traceroot/transport/span_processor.py
@@ -129,6 +129,9 @@ class TracerootSpanProcessor(BatchSpanProcessor):
         # concurrent sibling's on_start could look it up.
         self._ids_path_by_span_id: _PathMap = OrderedDict()
         self._name_path_by_span_id: _PathMap = OrderedDict()
+        # Unlike ids_path, each map value includes the mapped span's own start
+        # time so a child can inherit the complete root-to-parent chain.
+        self._starts_path_by_span_id: _PathMap = OrderedDict()
 
     def on_start(self, span, parent_context=None):
         if span.is_recording():
@@ -161,9 +164,12 @@ class TracerootSpanProcessor(BatchSpanProcessor):
                     parent_path: list | None = (
                         self._name_path_by_span_id.get(parent_id_hex) if parent_id_hex else None
                     )
+                    parent_starts_path: list | None = (
+                        self._starts_path_by_span_id.get(parent_id_hex) if parent_id_hex else None
+                    )
 
                     # Fall back to reading from the active parent span's attributes.
-                    if parent_ids_path is None or parent_path is None:
+                    if parent_ids_path is None or parent_path is None or parent_starts_path is None:
                         if parent_context is not None:
                             parent_span = otel_trace.get_current_span(parent_context)
                         else:
@@ -177,6 +183,13 @@ class TracerootSpanProcessor(BatchSpanProcessor):
                             raw_ids = attrs.get("traceroot.span.ids_path")
                             if raw_ids is not None:
                                 parent_ids_path = list(raw_ids)
+                            raw_starts = attrs.get("traceroot.span.starts_path")
+                            parent_start_time = getattr(parent_span, "start_time", None)
+                            if raw_starts is not None and parent_start_time is not None:
+                                parent_starts_path = [
+                                    *list(raw_starts),
+                                    str(parent_start_time),
+                                ]
 
                     span_name = getattr(span, "name", "") or ""
 
@@ -195,17 +208,40 @@ class TracerootSpanProcessor(BatchSpanProcessor):
                     else:
                         span_ids_path = []
 
+                    # starts_path: ancestor epoch-nanosecond start times in the
+                    # same root-to-parent order as ids_path. Never emit a partial
+                    # or malformed chain because it could associate a timestamp
+                    # with the wrong ancestor.
+                    if parent_id_hex and parent_starts_path is not None:
+                        candidate_starts_path = parent_starts_path
+                    else:
+                        candidate_starts_path = []
+
+                    starts_path_is_valid = len(candidate_starts_path) == len(span_ids_path) and all(
+                        isinstance(value, str) and value.isascii() and value.isdecimal()
+                        for value in candidate_starts_path
+                    )
+                    span_starts_path = list(candidate_starts_path) if starts_path_is_valid else []
+
                     # Store in map so descendant spans can inherit via lookup.
                     # Evict the oldest entry if we're at capacity.
                     span_id_hex = format(span.context.span_id, "016x")
                     if len(self._ids_path_by_span_id) >= _PATH_MAP_MAX:
-                        self._ids_path_by_span_id.popitem(last=False)
-                        self._name_path_by_span_id.popitem(last=False)
+                        oldest_span_id, _ = self._ids_path_by_span_id.popitem(last=False)
+                        self._name_path_by_span_id.pop(oldest_span_id, None)
+                        self._starts_path_by_span_id.pop(oldest_span_id, None)
                     self._ids_path_by_span_id[span_id_hex] = span_ids_path
                     self._name_path_by_span_id[span_id_hex] = span_path
+                    span_start_time = getattr(span, "start_time", None)
+                    self._starts_path_by_span_id[span_id_hex] = (
+                        [*span_starts_path, str(span_start_time)]
+                        if starts_path_is_valid and span_start_time is not None
+                        else []
+                    )
 
                 span.set_attribute("traceroot.span.path", span_path)
                 span.set_attribute("traceroot.span.ids_path", span_ids_path)
+                span.set_attribute("traceroot.span.starts_path", span_starts_path)
 
             except Exception as exc:
                 logger.debug("TracerootSpanProcessor: failed to set path attributes: %s", exc)
@@ -217,6 +253,7 @@ class TracerootSpanProcessor(BatchSpanProcessor):
             span_id_hex = format(span.context.span_id, "016x")
             self._ids_path_by_span_id.pop(span_id_hex, None)
             self._name_path_by_span_id.pop(span_id_hex, None)
+            self._starts_path_by_span_id.pop(span_id_hex, None)
         super().on_end(span)
 
     @property


### PR DESCRIPTION
## Summary

Fixes #142.

Adds `traceroot.span.starts_path`, containing each ancestor start time as an epoch-nanosecond string in the same root-to-parent order as `traceroot.span.ids_path`.

## Changes

- Track ancestor start times in a bounded internal map.
- Support recording and `NonRecordingSpan` parents.
- Keep timing-state eviction and cleanup synchronized with the existing path maps.
- Emit `[]` when timing state is incomplete or misaligned.
- Preserve existing `traceroot.span.path` and `traceroot.span.ids_path` behavior.

## Validation

- Added tests for nested spans and exact exported timestamps.
- Added recording-parent fallback and `NonRecordingSpan` coverage.
- Added corruption, eviction, and cleanup regression tests.
- `uv run pytest tests/ -q` — 816 passed.
- `uv run ruff check` — passed.
- `uv run ruff format --check` — passed.
- Focused tests also passed on Python 3.11.

I also reproduced the live sibling-branch scenario: descendants exported while their ancestors were still running carried the correct root and branch start times.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `traceroot.span.starts_path`, which carries ancestor start times (epoch nanoseconds) aligned with `traceroot.span.ids_path`. This lets downstream tools correlate spans with exact ancestor start times without reading parent spans.

- Emits `traceroot.span.starts_path` as a root-to-parent list of ASCII decimal strings; roots emit `[]`. Keeps existing `traceroot.span.path` and `traceroot.span.ids_path` unchanged.
- Validates alignment with `ids_path`; if state is missing or misaligned, emits `[]` to avoid incorrect timestamp-to-ancestor pairing.
- Supports `NonRecordingSpan` parents and falls back to reading recording-parent attributes and `start_time` when the map is missing.
- Tracks start times in a bounded map synchronized with the existing path maps; eviction removes the oldest entry across all maps, and `on_end` cleans all maps.

<sup>Written for commit 5e7b280b1f1322db0213b5bb2c049004d7803f6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

