### PR TITLE
test(eval): fix main — origin-scoped local_flag tests still used the removed `data=` alias

### DIFF
--- a/tests/eval/test_local_flag.py
+++ b/tests/eval/test_local_flag.py
@@ -350,7 +350,7 @@ class TestLocalSuppressesGlobalAutoInit:
                 client._provider.get_tracer("app").start_span("messages.create").end()
                 return x
 
-            evaluate(name="r", data=_dataset(), task=task, scorers=[exact], local=True)
+            evaluate(name="r", dataset=_dataset(), task=task, scorers=[exact], local=True)
 
             assert export_spy == []  # nothing the local run originated left the process
 
@@ -365,7 +365,9 @@ class TestLocalSuppressesGlobalAutoInit:
                 client._provider.get_tracer("app").start_span("messages.create").end()
                 return x
 
-            await evaluate_async(name="r", data=_dataset(), task=task, scorers=[exact], local=True)
+            await evaluate_async(
+                name="r", dataset=_dataset(), task=task, scorers=[exact], local=True
+            )
 
             assert export_spy == []
 
@@ -383,7 +385,7 @@ class TestLocalSuppressesGlobalAutoInit:
                 return x
 
             # This test is async, so a loop is already running on this thread -> the worker path.
-            evaluate(name="r", data=_dataset(), task=task, scorers=[exact], local=True)
+            evaluate(name="r", dataset=_dataset(), task=task, scorers=[exact], local=True)
 
             assert export_spy == []
 
@@ -444,7 +446,7 @@ class TestLocalSuppressesGlobalAutoInit:
                 held.append(client._provider.get_tracer("app").start_span("late.work"))
                 return x
 
-            evaluate(name="r", data=_dataset(), task=task, scorers=[exact], local=True)
+            evaluate(name="r", dataset=_dataset(), task=task, scorers=[exact], local=True)
 
             assert held and not held[0].is_recording()  # non-recording from birth
             for span in held:


### PR DESCRIPTION
## Summary

Fixes: main is red on `traceroot-py` after the export-gate merges.

Four tests added by the origin-scoped PR (#167) in `tests/eval/test_local_flag.py` call `evaluate(..., data=_dataset())` — the `data=` alias, which the separately-merged alias-removal PR (#166) deleted. The two PRs merged without a textual conflict but the combination is a **semantic** break: on `main`, `evaluate()` no longer accepts `data=`, so those tests raise `TypeError: evaluate() got an unexpected keyword argument 'data'`.

CI didn't catch it because #167's `Tests` ran against its base (`fix/eval-local-export-leak`, where `data=` still worked); retargeting to `main` didn't re-trigger the job, so it merged without running against the alias-removed `main`.

## What changed

`data=_dataset()` → `dataset=_dataset()` in the 4 origin-scoped tests (lines ~353/368/386/447). Test-only; the SDK code is correct. Internal `_run(data=...)` calls are untouched (the engine param is still `data`).

## Test plan

- [x] `uv run pytest tests/eval/test_local_flag.py -q` → 17 passed
- [x] `uv run ruff check` + `ruff format --check` clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes red CI on `main` by replacing the removed `data=` alias with `dataset=` in origin-scoped `local_flag` tests. Previously the tests called `evaluate(..., data=...)` and raised `TypeError`; now they call `dataset=` and pass.

- Tests only: changes limited to `tests/eval/test_local_flag.py`; production code untouched.
- Verified locally: the file’s tests pass; linters are clean.

<sup>Written for commit b17957cce227aea38f67250325fec4ee746131f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

