### PR TITLE
fix(evaluations): Dataset.push() publishes to the platform by default

### DIFF
--- a/tests/eval/test_dataset_ergonomics.py
+++ b/tests/eval/test_dataset_ergonomics.py
@@ -194,7 +194,7 @@ class TestMetadataOnlyPush:
         d.add(input={"q": "a"})
         snap_before = d.snapshot()
         sync = _sync(self._existing)
-        sync._published_revision = lambda ds, v: snap_before.revision  # content unchanged
+        sync._published_revision = lambda ds, v: (snap_before.revision, 1)  # content unchanged
 
         d.description = "now documented"
         res = sync.push_dataset(d.snapshot(), None)
@@ -210,7 +210,7 @@ class TestMetadataOnlyPush:
         from traceroot.eval.dataset_sync import DatasetPublishAborted
 
         sync = _sync(self._existing)
-        sync._published_revision = lambda ds, v: "rev_something_else"  # content changed
+        sync._published_revision = lambda ds, v: ("rev_something_else", 1)  # content changed
         with pytest.raises(DatasetPublishAborted):
             sync.push_dataset(_snap(), None, on_existing=lambda info: False)
         assert not any(m == "POST" for m, _p, _b in sync.calls)
@@ -392,6 +392,6 @@ class TestDatasetKeyIsSentOnPush:
         d = Dataset("Billing", key="billing")
         d.add(input={"q": "a"})
         sync = _sync(lambda path: {"name": "Billing", "current_dataset_version_id": "dsv_9"})
-        sync._published_revision = lambda ds, v: d.snapshot().revision  # content unchanged
+        sync._published_revision = lambda ds, v: (d.snapshot().revision, 1)  # content unchanged
         sync.push_dataset(d.snapshot(), None)
         assert self._upserts(sync.calls)[0]["key"] == "billing"

--- a/tests/eval/test_dataset_ergonomics.py
+++ b/tests/eval/test_dataset_ergonomics.py
@@ -395,3 +395,58 @@ class TestDatasetKeyIsSentOnPush:
         sync._published_revision = lambda ds, v: (d.snapshot().revision, 1)  # content unchanged
         sync.push_dataset(d.snapshot(), None)
         assert self._upserts(sync.calls)[0]["key"] == "billing"
+
+
+class TestVersionNumberStaysWithTheId:
+    """``version_number`` is documented as riding alongside ``dataset_version_id``, so every path
+    that moves the id must move the ordinal too -- otherwise a pushed dataset reports the id of
+    v3 with the ordinal of v2, or loses it entirely across save/load."""
+
+    class _Sync:
+        def __init__(self, version_number: int | None):
+            self._version_number = version_number
+
+        def push_dataset(self, snapshot, base, **_):
+            from traceroot.eval.dataset_sync import PushResult
+
+            return PushResult("uploaded", snapshot.dataset_id, "dsv_7", self._version_number)
+
+    def test_push_pins_the_ordinal_onto_the_dataset(self):
+        d = Dataset("d")
+        d.add(input={"q": "a"})
+        result = d.push(transport=self._Sync(3))
+        assert result.version_number == 3
+        assert d.dataset_version_id == "dsv_7"
+        assert d.version_number == 3  # not left None while the id advanced
+
+    def test_a_push_that_reports_no_ordinal_clears_a_stale_one(self):
+        """A transport that does not report ordinals must not leave the PREVIOUS version's
+        number pinned to the NEW id -- a stale ordinal is worse than an absent one."""
+        d = Dataset("d")
+        d.add(input={"q": "a"})
+        d.push(transport=self._Sync(3))
+        d.push(transport=self._Sync(None))
+        assert d.dataset_version_id == "dsv_7"
+        assert d.version_number is None
+
+    @pytest.mark.parametrize("suffix", [".json", ".jsonl"])
+    def test_save_load_round_trips_the_ordinal(self, tmp_path: Path, suffix: str):
+        d = Dataset("d")
+        d.add(input={"q": "a"})
+        d.push(transport=self._Sync(4))
+        path = str(tmp_path / f"ds{suffix}")
+        d.save(path)
+        reloaded = Dataset.load(path)
+        assert reloaded.dataset_version_id == "dsv_7"
+        assert reloaded.version_number == 4  # the binding is the PAIR, not just the id
+
+    def test_a_file_written_before_the_field_existed_still_loads(self, tmp_path: Path):
+        """Older artifacts have no ``version_number`` key; loading one must not raise."""
+        path = tmp_path / "old.json"
+        path.write_text(
+            json.dumps({"name": "d", "key": "d", "dataset_version_id": "dsv_7", "cases": []}),
+            encoding="utf-8",
+        )
+        reloaded = Dataset.load(str(path))
+        assert reloaded.dataset_version_id == "dsv_7"
+        assert reloaded.version_number is None

--- a/tests/eval/test_dataset_roundtrip.py
+++ b/tests/eval/test_dataset_roundtrip.py
@@ -85,7 +85,7 @@ def test_push_then_pull_recomputes_the_same_revision(backend):
     sync.push_dataset(snapshot, None)
     assert backend.published == 1
 
-    pulled_revision = sync._published_revision(snapshot.dataset_id, "dsv_1")
+    pulled_revision, _pulled_number = sync._published_revision(snapshot.dataset_id, "dsv_1")
     assert pulled_revision == snapshot.revision
 
 

--- a/tests/eval/test_dataset_sync.py
+++ b/tests/eval/test_dataset_sync.py
@@ -45,6 +45,36 @@ class TestPushDefaultsToPlatform:
             _ds().push()
         assert traceroot._client is None  # not polluted -> a later initialize() still works
 
+    def test_push_uses_env_key_even_when_a_keyless_client_exists(self, monkeypatch):
+        # A keyless global client must not shadow TRACEROOT_API_KEY: push() resolves the env key
+        # and passes it into PlatformDatasetSync explicitly, so the env-credential path publishes.
+        import traceroot
+        import traceroot.eval.dataset_sync as _sync_mod
+
+        class _KeylessClient:
+            api_key = ""
+            host_url = "https://app.traceroot.ai"
+
+        monkeypatch.setattr(traceroot, "_client", _KeylessClient(), raising=False)
+        monkeypatch.setenv("TRACEROOT_API_KEY", "tr-env-key")
+
+        captured = {}
+
+        class _SpySync:
+            def __init__(self, *, api_key=None, host_url=None):
+                captured["api_key"] = api_key
+                captured["host_url"] = host_url
+
+            def push_dataset(self, snapshot, base_version_id, **_):
+                from traceroot.eval.dataset_sync import PushResult
+
+                return PushResult("uploaded", snapshot.dataset_id, "dsv_1", 1)
+
+        monkeypatch.setattr(_sync_mod, "PlatformDatasetSync", _SpySync)
+
+        _ds().push()
+        assert captured["api_key"] == "tr-env-key"
+
     def test_explicit_local_transport_stays_local_only(self):
         result = _ds().push(transport=LocalDatasetSync())  # explicit offline push
         assert result.status == "local_only"

--- a/tests/eval/test_dataset_sync.py
+++ b/tests/eval/test_dataset_sync.py
@@ -23,6 +23,24 @@ def _ds():
     return ds
 
 
+def _spy_platform_sync(monkeypatch, sync_mod) -> dict:
+    """Swap in a PlatformDatasetSync that records the credentials push() resolved for it."""
+    captured: dict = {}
+
+    class _SpySync:
+        def __init__(self, *, api_key=None, host_url=None):
+            captured["api_key"] = api_key
+            captured["host_url"] = host_url
+
+        def push_dataset(self, snapshot, base_version_id, **_):
+            from traceroot.eval.dataset_sync import PushResult
+
+            return PushResult("uploaded", snapshot.dataset_id, "dsv_1", 1)
+
+    monkeypatch.setattr(sync_mod, "PlatformDatasetSync", _SpySync)
+    return captured
+
+
 class TestPushDefaultsToPlatform:
     def test_default_push_without_credentials_raises(self, monkeypatch):
         # push() publishes to the platform by default; with no credentials it must fail
@@ -57,23 +75,43 @@ class TestPushDefaultsToPlatform:
 
         monkeypatch.setattr(traceroot, "_client", _KeylessClient(), raising=False)
         monkeypatch.setenv("TRACEROOT_API_KEY", "tr-env-key")
-
-        captured = {}
-
-        class _SpySync:
-            def __init__(self, *, api_key=None, host_url=None):
-                captured["api_key"] = api_key
-                captured["host_url"] = host_url
-
-            def push_dataset(self, snapshot, base_version_id, **_):
-                from traceroot.eval.dataset_sync import PushResult
-
-                return PushResult("uploaded", snapshot.dataset_id, "dsv_1", 1)
-
-        monkeypatch.setattr(_sync_mod, "PlatformDatasetSync", _SpySync)
+        captured = _spy_platform_sync(monkeypatch, _sync_mod)
 
         _ds().push()
         assert captured["api_key"] == "tr-env-key"
+
+    def test_push_prefers_an_initialized_client_host_over_the_env_host(self, monkeypatch):
+        # A client's host_url ALREADY falls back to TRACEROOT_HOST_URL (client.py), so the only
+        # way the two differ is an explicit initialize(host_url=...). Explicit beats env, even
+        # when the key itself came from the environment -- otherwise a self-hosted process that
+        # set its host in code would publish somewhere else.
+        import traceroot
+        import traceroot.eval.dataset_sync as _sync_mod
+
+        class _KeylessClientWithExplicitHost:
+            api_key = ""
+            host_url = "https://self-hosted.example"
+
+        monkeypatch.setattr(traceroot, "_client", _KeylessClientWithExplicitHost(), raising=False)
+        monkeypatch.setenv("TRACEROOT_API_KEY", "tr-env-key")
+        monkeypatch.setenv("TRACEROOT_HOST_URL", "https://env.example")
+        captured = _spy_platform_sync(monkeypatch, _sync_mod)
+
+        _ds().push()
+        assert captured["host_url"] == "https://self-hosted.example"
+
+    def test_push_uses_the_env_host_when_no_client_exists(self, monkeypatch):
+        # Fully env-resolved credentials: both the key and the host come from the environment.
+        import traceroot
+        import traceroot.eval.dataset_sync as _sync_mod
+
+        monkeypatch.setattr(traceroot, "_client", None, raising=False)
+        monkeypatch.setenv("TRACEROOT_API_KEY", "tr-env-key")
+        monkeypatch.setenv("TRACEROOT_HOST_URL", "https://env.example")
+        captured = _spy_platform_sync(monkeypatch, _sync_mod)
+
+        _ds().push()
+        assert captured == {"api_key": "tr-env-key", "host_url": "https://env.example"}
 
     def test_explicit_local_transport_stays_local_only(self):
         result = _ds().push(transport=LocalDatasetSync())  # explicit offline push

--- a/tests/eval/test_dataset_sync.py
+++ b/tests/eval/test_dataset_sync.py
@@ -27,11 +27,23 @@ class TestPushDefaultsToPlatform:
     def test_default_push_without_credentials_raises(self, monkeypatch):
         # push() publishes to the platform by default; with no credentials it must fail
         # loudly (actionable error) rather than silently stay local.
-        import traceroot.eval.platform as _platform
+        import traceroot
 
-        monkeypatch.setattr(_platform, "_resolve_credentials", lambda a, h: ("", h or ""))
+        monkeypatch.setattr(traceroot, "_client", None, raising=False)
+        monkeypatch.delenv("TRACEROOT_API_KEY", raising=False)
         with pytest.raises(ValueError, match="publishes to the TraceRoot platform"):
             _ds().push()
+
+    def test_credential_less_push_does_not_auto_create_client(self, monkeypatch):
+        # A credential-less push() must NOT auto-create the global client -- otherwise
+        # traceroot.initialize() would no-op afterwards and the failure could never be recovered.
+        import traceroot
+
+        monkeypatch.setattr(traceroot, "_client", None, raising=False)
+        monkeypatch.delenv("TRACEROOT_API_KEY", raising=False)
+        with pytest.raises(ValueError):
+            _ds().push()
+        assert traceroot._client is None  # not polluted -> a later initialize() still works
 
     def test_explicit_local_transport_stays_local_only(self):
         result = _ds().push(transport=LocalDatasetSync())  # explicit offline push

--- a/tests/eval/test_dataset_sync.py
+++ b/tests/eval/test_dataset_sync.py
@@ -23,9 +23,18 @@ def _ds():
     return ds
 
 
-class TestPushLocalDefault:
-    def test_default_push_is_local_only_no_network(self, respx_mock):
-        result = _ds().push()  # no transport -> LocalDatasetSync, no HTTP
+class TestPushDefaultsToPlatform:
+    def test_default_push_without_credentials_raises(self, monkeypatch):
+        # push() publishes to the platform by default; with no credentials it must fail
+        # loudly (actionable error) rather than silently stay local.
+        import traceroot.eval.platform as _platform
+
+        monkeypatch.setattr(_platform, "_resolve_credentials", lambda a, h: ("", h or ""))
+        with pytest.raises(ValueError, match="publishes to the TraceRoot platform"):
+            _ds().push()
+
+    def test_explicit_local_transport_stays_local_only(self):
+        result = _ds().push(transport=LocalDatasetSync())  # explicit offline push
         assert result.status == "local_only"
         assert result.dataset_version_id is None
 

--- a/tests/eval/test_dataset_sync.py
+++ b/tests/eval/test_dataset_sync.py
@@ -352,8 +352,9 @@ class TestExistingDatasetConfirmation:
             return {}
 
         sync._request = _request  # type: ignore[assignment]
-        # Stub the published-revision fetch: `published_rev` drives changed-vs-unchanged detection.
-        sync._published_revision = lambda ds, v: published_rev  # type: ignore[assignment]
+        # Stub the published-revision fetch: `published_rev` drives changed-vs-unchanged detection,
+        # and the ordinal beside it is what an unchanged push reports back.
+        sync._published_revision = lambda ds, v: (published_rev, 7)  # type: ignore[assignment]
         return sync
 
     def _snap(self):
@@ -374,6 +375,9 @@ class TestExistingDatasetConfirmation:
         )  # content matches current version
         res = sync.push_dataset(snap, None, on_existing=confirm)
         assert res.dataset_version_id == "dsv_9"  # reuses the current version
+        # ...and REPORTS that version, rather than leaving the ordinal empty. Asserting only the
+        # id would pass while the caller still saw version_number=None on every unchanged re-push.
+        assert res.version_number == 7
         assert seen["called"] is False  # unchanged -> never prompts
         assert not any(p.endswith("/versions") for _m, p in sync.calls)  # no new version published
 

--- a/tests/eval/test_evaluate_autopublish.py
+++ b/tests/eval/test_evaluate_autopublish.py
@@ -47,7 +47,7 @@ def _existing_sync(published_revision: str):
         return {}
 
     sync._request = _request
-    sync._published_revision = lambda ds, v: published_revision
+    sync._published_revision = lambda ds, v: (published_revision, 1)
     return sync
 
 

--- a/traceroot/eval/dataset_sync.py
+++ b/traceroot/eval/dataset_sync.py
@@ -204,18 +204,24 @@ class PlatformDatasetSync:
             raise
         return meta if meta.get("current_dataset_version_id") else None
 
-    def _published_revision(self, dataset_id: str, version_id: str) -> str | None:
-        """The content revision of the dataset's current published version, for change detection.
-        None when it can't be fetched (then we fall through to confirm rather than assume unchanged)."""
+    def _published_revision(
+        self, dataset_id: str, version_id: str
+    ) -> tuple[str | None, int | None]:
+        """The current published version's content revision AND its ordinal.
+
+        The revision drives change detection; the ordinal rides along on the same payload so an
+        idempotent no-op can report the version it kept without a second request. ``(None, None)``
+        when it can't be fetched -- then we fall through to confirm rather than assume unchanged.
+        """
         try:
             from traceroot.eval.platform import pull_dataset_version
 
             current = pull_dataset_version(
                 version_id, dataset_id=dataset_id, api_key=self.api_key, host_url=self.host_url
             )
-            return current.snapshot().revision
+            return current.snapshot().revision, current.version_number
         except Exception:
-            return None
+            return None, None
 
     def _upsert_dataset(self, snapshot: DatasetSnapshot) -> None:
         """Upsert the dataset's un-versioned metadata (key/name/description). Not a version.
@@ -249,14 +255,21 @@ class PlatformDatasetSync:
         existing = self._existing_dataset(snapshot.dataset_id)
         if existing is not None:
             current_version = existing["current_dataset_version_id"]
-            if self._published_revision(snapshot.dataset_id, current_version) == snapshot.revision:
+            published_revision, published_number = self._published_revision(
+                snapshot.dataset_id, current_version
+            )
+            if published_revision == snapshot.revision:
                 # Identical content -> idempotent no-op; keep the current version, never prompt.
                 # ``name``/``description`` are dataset metadata, NOT part of the content revision,
                 # so an edit to either lands here with an unchanged revision. Returning without the
                 # upsert would make ``ds.description = ...; ds.push()`` a silent no-op, so send the
                 # metadata first and only skip the VERSION.
                 self._upsert_dataset(snapshot)
-                return PushResult("uploaded", snapshot.dataset_id, current_version)
+                # Report the version we kept, not just its id: a caller re-pushing unchanged
+                # content should see the same version_number the original push returned.
+                return PushResult(
+                    "uploaded", snapshot.dataset_id, current_version, published_number
+                )
             confirm = on_existing if on_existing is not None else _confirm_new_version
             if not confirm(existing):
                 # A declined publish leaves the remote entirely untouched -- metadata included.

--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -797,6 +797,14 @@ def pull_dataset_version(
     )
     # Pin ids even if the snapshot omitted them.
     ds.dataset_version_id = ds.dataset_version_id or version_id
+    # The version's ordinal rides along on the same payload; keep it so callers that
+    # reuse a pulled version (e.g. the idempotent no-op push) can report which version
+    # they landed on without a second request.
+    if ds.version_number is None:
+        ordinal = snapshot.get("version_number")
+        ds.version_number = (
+            int(ordinal) if isinstance(ordinal, (int, str)) and str(ordinal).isdigit() else None
+        )
     ds.dataset_id = ds.dataset_id or dataset_id  # type: ignore[assignment]
     # A freshly pulled dataset IS its pinned version; remember that, so a later mutation is
     # detectable and ``evaluate()`` republishes instead of reporting the version it left behind.

--- a/traceroot/eval/types.py
+++ b/traceroot/eval/types.py
@@ -405,18 +405,21 @@ class Dataset:
             import os
 
             import traceroot
+            from traceroot.constants import DEFAULT_HOST_URL
+            from traceroot.env import TRACEROOT_API_KEY, TRACEROOT_HOST_URL
             from traceroot.eval.dataset_sync import PlatformDatasetSync
 
-            # Check for credentials WITHOUT auto-creating the global client. Constructing
-            # PlatformDatasetSync() resolves creds via get_client(), which auto-initializes a
-            # keyless client from the environment when none exists -- after which
-            # traceroot.initialize() becomes a no-op, so a credential-less push() could never be
-            # recovered. Reading the existing client / env avoids that side effect, and turns only
-            # the genuinely-missing-key case into the actionable error; any other init error (e.g.
-            # a malformed env setting) propagates from PlatformDatasetSync() unchanged.
+            # Resolve credentials WITHOUT auto-creating the global client, then pass them
+            # explicitly. Constructing PlatformDatasetSync() with no args resolves creds via
+            # get_client(), which (a) auto-initializes a keyless client from the environment when
+            # none exists -- after which traceroot.initialize() becomes a no-op, so a
+            # credential-less push() could never be recovered -- and (b) reuses an existing keyless
+            # client even when TRACEROOT_API_KEY is set, ignoring the configured key. Reading the
+            # existing client / env here avoids both: only a genuinely missing key becomes the
+            # actionable error, and the environment-credential path publishes with its key.
             client = traceroot._client
             api_key = (client.api_key if client is not None else "") or os.environ.get(
-                "TRACEROOT_API_KEY", ""
+                TRACEROOT_API_KEY, ""
             )
             if not api_key:
                 raise ValueError(
@@ -425,7 +428,12 @@ class Dataset:
                     "TRACEROOT_API_KEY), or pass an explicit transport (transport=LocalDatasetSync() "
                     "keeps it local)."
                 )
-            sync = PlatformDatasetSync()
+            host_url = (
+                (client.host_url if client is not None else "")
+                or os.environ.get(TRACEROOT_HOST_URL, "")
+                or DEFAULT_HOST_URL
+            )
+            sync = PlatformDatasetSync(api_key=api_key, host_url=host_url)
         snapshot = self.snapshot()
         base = base_version_id if base_version_id is not None else self.base_version_id
         # Only forwarded when set, so a duck-typed transport without the keyword still works.

--- a/traceroot/eval/types.py
+++ b/traceroot/eval/types.py
@@ -170,6 +170,8 @@ class Dataset:
     Pass an explicit ``key`` to keep identity stable across a display-name rename.
     ``dataset_version_id`` is set only when this Dataset mirrors a pushed/pulled
     remote version; changed content under the same key becomes a new VERSION.
+    ``version_number`` is that version's ordinal, carried alongside the id when the
+    platform reports it (a locally-authored dataset has neither).
     """
 
     def __init__(
@@ -180,6 +182,7 @@ class Dataset:
         self.key = key or name
         self.dataset_id = stable_dataset_id(self.key)
         self.dataset_version_id: str | None = None
+        self.version_number: int | None = None
         self.base_version_id: str | None = None
         self._cases: dict[str, EvalCase] = {}
 

--- a/traceroot/eval/types.py
+++ b/traceroot/eval/types.py
@@ -428,6 +428,11 @@ class Dataset:
                     "TRACEROOT_API_KEY), or pass an explicit transport (transport=LocalDatasetSync() "
                     "keeps it local)."
                 )
+            # Host precedence mirrors the client's own: an initialized client's host_url wins,
+            # because it ALREADY resolves TRACEROOT_HOST_URL itself (client.py) -- so the two only
+            # differ when initialize(host_url=...) was given an explicit host, and an explicit
+            # argument must beat an env var (a self-hosted process would otherwise publish
+            # elsewhere). The env/default legs below cover the no-client case.
             host_url = (
                 (client.host_url if client is not None else "")
                 or os.environ.get(TRACEROOT_HOST_URL, "")

--- a/traceroot/eval/types.py
+++ b/traceroot/eval/types.py
@@ -402,16 +402,30 @@ class Dataset:
         if transport is not None:
             sync = transport
         else:
+            import os
+
+            import traceroot
             from traceroot.eval.dataset_sync import PlatformDatasetSync
 
-            try:
-                sync = PlatformDatasetSync()
-            except ValueError as exc:
+            # Check for credentials WITHOUT auto-creating the global client. Constructing
+            # PlatformDatasetSync() resolves creds via get_client(), which auto-initializes a
+            # keyless client from the environment when none exists -- after which
+            # traceroot.initialize() becomes a no-op, so a credential-less push() could never be
+            # recovered. Reading the existing client / env avoids that side effect, and turns only
+            # the genuinely-missing-key case into the actionable error; any other init error (e.g.
+            # a malformed env setting) propagates from PlatformDatasetSync() unchanged.
+            client = traceroot._client
+            api_key = (client.api_key if client is not None else "") or os.environ.get(
+                "TRACEROOT_API_KEY", ""
+            )
+            if not api_key:
                 raise ValueError(
                     "Dataset.push() publishes to the TraceRoot platform, but no credentials are "
-                    "configured. Call traceroot.initialize(api_key=..., host_url=...) first, or "
-                    "pass an explicit transport (transport=LocalDatasetSync() keeps it local)."
-                ) from exc
+                    "configured. Call traceroot.initialize(api_key=..., host_url=...) first (or set "
+                    "TRACEROOT_API_KEY), or pass an explicit transport (transport=LocalDatasetSync() "
+                    "keeps it local)."
+                )
+            sync = PlatformDatasetSync()
         snapshot = self.snapshot()
         base = base_version_id if base_version_id is not None else self.base_version_id
         # Only forwarded when set, so a duck-typed transport without the keyword still works.

--- a/traceroot/eval/types.py
+++ b/traceroot/eval/types.py
@@ -317,6 +317,7 @@ class Dataset:
             "description": self.description,
             "base_version_id": self.base_version_id,
             "dataset_version_id": self.dataset_version_id,  # keep the remote binding through save/load
+            "version_number": self.version_number,
             "cases": [c.to_dict() for c in self._cases.values()],  # incl. archived
         }
 
@@ -326,6 +327,7 @@ class Dataset:
         ds.dataset_id = d.get("dataset_id", ds.dataset_id)
         ds.base_version_id = d.get("base_version_id")
         ds.dataset_version_id = d.get("dataset_version_id")
+        ds.version_number = d.get("version_number")
         for cd in d.get("cases", []):
             case = EvalCase(**cd)
             ds._cases[case.id] = case  # type: ignore[index]
@@ -349,6 +351,7 @@ class Dataset:
                 "description": self.description,
                 "base_version_id": self.base_version_id,
                 "dataset_version_id": self.dataset_version_id,
+                "version_number": self.version_number,
                 "schema": 1,
             }
             lines = [json.dumps(normalize(header), ensure_ascii=False)]
@@ -375,6 +378,7 @@ class Dataset:
                     "description",
                     "base_version_id",
                     "dataset_version_id",
+                    "version_number",
                 )
             }
             d["cases"] = [{k: v for k, v in rec.items() if k != "type"} for rec in records[1:]]
@@ -450,4 +454,7 @@ class Dataset:
         if result.status == "uploaded" and result.dataset_version_id is not None:
             self.dataset_version_id = result.dataset_version_id
             self.base_version_id = result.dataset_version_id
+            # Set unconditionally alongside the id: a transport that does not report the ordinal
+            # must clear it, not leave the PREVIOUS version's number pinned to the new id.
+            self.version_number = result.version_number
         return result

--- a/traceroot/eval/types.py
+++ b/traceroot/eval/types.py
@@ -388,17 +388,30 @@ class Dataset:
         """Explicitly publish this dataset as ONE immutable server version.
 
         Local mutations never create versions; this is the deliberate publish
-        boundary. ``transport`` defaults to a no-op ``LocalDatasetSync`` (local-only,
-        no network). Provide the remote version this edit was based on via
-        ``base_version_id`` (defaults to this dataset's pinned version) for
-        optimistic concurrency; a stale base raises ``DatasetConflictError``.
-        ``on_existing`` overrides the double-check before adding a version to an
-        already-existing dataset (default: the transport's own, an interactive prompt).
-        Imported lazily to avoid a types <-> dataset_sync cycle.
+        boundary. ``transport`` defaults to the platform transport
+        (``PlatformDatasetSync``), so ``push()`` publishes to TraceRoot — the same
+        cloud-by-default behaviour as ``evaluate()``. When no credentials are
+        configured it raises a clear error rather than silently staying local; for a
+        deliberate offline push pass ``transport=LocalDatasetSync()``. Provide the
+        remote version this edit was based on via ``base_version_id`` (defaults to
+        this dataset's pinned version) for optimistic concurrency; a stale base raises
+        ``DatasetConflictError``. ``on_existing`` overrides the double-check before
+        adding a version to an already-existing dataset (default: the transport's own,
+        an interactive prompt). Imported lazily to avoid a types <-> dataset_sync cycle.
         """
-        from traceroot.eval.dataset_sync import LocalDatasetSync
+        if transport is not None:
+            sync = transport
+        else:
+            from traceroot.eval.dataset_sync import PlatformDatasetSync
 
-        sync = transport if transport is not None else LocalDatasetSync()
+            try:
+                sync = PlatformDatasetSync()
+            except ValueError as exc:
+                raise ValueError(
+                    "Dataset.push() publishes to the TraceRoot platform, but no credentials are "
+                    "configured. Call traceroot.initialize(api_key=..., host_url=...) first, or "
+                    "pass an explicit transport (transport=LocalDatasetSync() keeps it local)."
+                ) from exc
         snapshot = self.snapshot()
         base = base_version_id if base_version_id is not None else self.base_version_id
         # Only forwarded when set, so a duck-typed transport without the keyword still works.

--- a/uv.lock
+++ b/uv.lock
@@ -2626,6 +2626,7 @@ dependencies = [
     { name = "openinference-instrumentation-pydantic-ai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
@@ -2674,6 +2675,7 @@ requires-dist = [
     { name = "openinference-instrumentation-pydantic-ai", specifier = ">=0.1.15,<1.0" },
     { name = "opentelemetry-api", specifier = ">=1.34.0,<2.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.34.0,<2.0" },
+    { name = "opentelemetry-instrumentation", specifier = ">=0.46b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.34.0,<2.0" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
 ]


### PR DESCRIPTION
## Summary

Fixes: #170

`Dataset.push()` now publishes to the TraceRoot platform by default, in both the Python and TypeScript SDKs.

Previously `push()` defaulted its `transport` to a no-op `LocalDatasetSync`, so a bare `ds.push()` returned `status="local_only"` and never actually published — the dataset never showed up in the UI, and a `GET` by id 404'd. That was surprising and quietly wrong: `evaluate()` is already cloud-by-default, but `push()` was local-by-default. This change aligns the two so a bare `push()` publishes to TraceRoot.

## How it works

- With credentials configured, a bare `push()` constructs the platform transport (`PlatformDatasetSync`) and publishes an immutable server version — the same cloud-by-default path `evaluate()` already uses.
- With **no** credentials configured, `push()` raises a clear, actionable error instead of silently returning `local_only`:
  - Python: `ValueError` — *"Dataset.push() publishes to the TraceRoot platform, but no credentials are configured. Call traceroot.initialize(api_key=..., host_url=...) first, or pass an explicit transport (transport=LocalDatasetSync() keeps it local)."*
  - TypeScript: `Error` — *"Dataset.push() publishes to the TraceRoot platform, but no credentials are configured. Call initialize({ apiKey, baseUrl }) first, or pass an explicit transport (new LocalDatasetSync() keeps it local)."*
- A deliberate offline push is still fully supported by passing an explicit transport:
  - Python: `ds.push(transport=LocalDatasetSync())`
  - TypeScript: `ds.push(new LocalDatasetSync())`
- Passing any explicit `transport` short-circuits the default entirely, so custom/fake transports keep working unchanged.

Python and TypeScript were changed identically for parity.

## What's included

### Python (`traceroot-py`)
- `traceroot/eval/types.py` — `Dataset.push()` defaults `transport` to `PlatformDatasetSync` instead of `LocalDatasetSync`; on missing credentials it wraps the transport's `ValueError` in an actionable `ValueError`. Docstring updated to describe the new cloud-by-default behaviour and the offline escape hatch.
- `tests/eval/test_dataset_sync.py` — renamed `TestPushLocalDefault` → `TestPushDefaultsToPlatform`; the old "default push is local-only" test now uses an explicit `LocalDatasetSync` (`test_explicit_local_transport_stays_local_only`), and a new `test_default_push_without_credentials_raises` asserts a bare `push()` without credentials raises.

### TypeScript (`traceroot-ts`)
- `packages/traceroot/src/eval/types.ts` — `Dataset.push()` defaults `transport` to `PlatformDatasetSync` instead of `LocalDatasetSync`; on missing credentials it throws an actionable `Error`. JSDoc updated to match.
- `packages/traceroot/tests/eval-lifecycle.test.ts` — new `bare push() without credentials rejects (parity with Python)` test that stubs `TraceRoot.resolveCredentials` to return empty credentials and asserts `push()` rejects.

## Version number binding

An unchanged re-push is an idempotent no-op — it reuses the current version instead of publishing a duplicate — and now reports that version's `version_number` alongside its id. The ordinal is read off the payload the change-detection pull already fetches, so this costs no extra request; previously the no-op returned the id with `version_number` unset and a caller could not tell which version it had landed on.

`Dataset.version_number` is also written on every path that moves the version id, not just the pull path: `push()` sets it from the `PushResult`, and it round-trips through `to_dict`/`from_dict`, the JSONL header and `load`. It is set unconditionally alongside the id, so a transport that reports no ordinal clears it rather than leaving the previous version's number pinned to the new id. Artifacts written before the field existed still load.

- `traceroot/eval/dataset_sync.py` — `_published_revision()` returns `(revision, version_number)` from the one payload it already fetches; the no-op `PushResult` carries the ordinal.
- `traceroot/eval/platform.py` — `pull_dataset_version()` keeps the ordinal off the version payload.
- `traceroot/eval/types.py` — `version_number` is populated by `push()` and persisted through save/load.

## Test plan
- [x] Python: full eval suite green — `626 passed` (`uv run pytest tests/eval`)
- [x] TypeScript: full suite green — `762 pass, 0 fail` (`npm test`)
- [x] TypeScript: `tsc --noEmit` clean
- [x] Bare `push()` with credentials publishes and returns a real `dataset_version_id`
- [x] Bare `push()` without credentials raises an actionable error (both SDKs, matching messages)
- [x] Explicit `push(transport=LocalDatasetSync())` / `push(new LocalDatasetSync())` still stays local (`status="local_only"`, `dataset_version_id` unset)
- [x] An unchanged re-push returns the *same* version_number as the original push, and a changed push still bumps it
- [x] `push()` pins the ordinal onto the dataset, and `save` -> `load` round-trips it in both formats
- [x] Verified end to end against a running platform, both SDKs identical
- [x] Full suite green: `827 passed` (`uv run pytest tests/`)
