### PR TITLE
refactor(eval): drop the dead pass_threshold kwarg from PlatformTransport

### DIFF
--- a/traceroot/eval/platform.py
+++ b/traceroot/eval/platform.py
@@ -288,7 +288,6 @@ class PlatformTransport:
         environment: str = "evaluation",
         dataset_version_id: str | None = None,
         client_run_id: str | None = None,
-        pass_threshold: float | None = None,
         scorer_specs: list[dict[str, Any]] | None = None,
         evaluation_key: str | None = None,
         api_key: str | None = None,
@@ -308,7 +307,6 @@ class PlatformTransport:
         self.environment = environment
         self.dataset_version_id = dataset_version_id
         self.client_run_id = client_run_id
-        self.pass_threshold = pass_threshold
         self.api_key, self.host_url = _resolve_credentials(api_key, host_url)
         if not self.api_key:
             raise ValueError(


### PR DESCRIPTION
## Summary

Fixes: #172

`PlatformTransport.__init__` accepted `pass_threshold: float | None`, stored it on `self.pass_threshold`, and never read it again. Those two lines (`traceroot/eval/platform.py:291` and `:311`) were the only occurrences of the identifier in the package, so the value reached no request payload and changed no run's pass/fail — a caller setting `pass_threshold=0.8` to gate a run got a silent no-op that reads as configuration.

It was live once: it fed the pass/fail branch in `_status_and_main`. That branch was deleted when `main_score` was removed and per-case status became `errored | not_scored`, with per-score `passed` carrying the metric signal. The parameter and its assignment were left behind. Per-metric thresholds already travel to the platform on `scorer_specs`, which is the mechanism that actually works.

This PR deletes both lines. Nothing else changes.

## Why straight removal, and not a deprecation shim

Removing a keyword from a public constructor is a breaking change even when the keyword does nothing, so the alternative — accept and ignore with a `DeprecationWarning` for one release — deserved a look. Repo precedent settles it, and it is unanimous:

- `main_score_name` was a public keyword on **this same constructor** and was removed outright (`422ae8b`), no shim.
- `data=`, a *documented* public alias on `evaluate()`, was removed outright six days ago (`1686981`), with `dataset` made required — again no shim.
- `DeprecationWarning` appears nowhere in the package.

Beyond precedent: a warning period exists to preserve behaviour while callers migrate, and there is no behaviour here to preserve — the keyword has been inert since the `main_score` removal. `TypeError` at construction is also the more informative outcome. A caller passing `pass_threshold=0.8` believes a gate is enforced; failing loudly surfaces that belief immediately, whereas a warning they may have filtered out leaves the wrong belief in place. The package is `0.2.0`.

Both in-package construction sites (`traceroot/eval/engine.py:637`, `traceroot/eval/results.py:395`) pass explicit keywords and neither passed `pass_threshold`. The backend has no `pass_threshold` / `passThreshold` field on any evaluation endpoint, so the removal is invisible over the wire — no coordinated deploy.

## Verification

- `git grep -n pass_threshold` — before: the two `platform.py` lines. After: no occurrences.
- Package imports and the transport constructs unchanged: `PlatformTransport("ds_123", api_key=..., host_url=...)` succeeds, `hasattr(t, "pass_threshold")` is now `False`, and the signature is `[self, dataset_id, scorer_names, candidate_version, environment, dataset_version_id, client_run_id, scorer_specs, evaluation_key, api_key, host_url]`.
- Passing the keyword now raises `TypeError: PlatformTransport.__init__() got an unexpected keyword argument 'pass_threshold'`.
- Full suite, before and after: `817 passed`. Sixteen test files construct `PlatformTransport`; none passed the keyword, so none needed a change.
- `ruff check` → `All checks passed!`; `ruff format --check` → `97 files already formatted` (ruff `0.15.0`, the version CI pins).

## Scope

One file, two deleted lines. No new tests: the change removes a code path rather than adding one, and asserting `TypeError` on an unexpected keyword would test the language, not the package — neither prior keyword removal added such a test. No migration, no API payload change, no docs reference the keyword.
