### PR TITLE
feat: emit the Anthropic 1h cache-write token split

### DIFF
--- a/tests/eval/test_judge_token_counts.py
+++ b/tests/eval/test_judge_token_counts.py
@@ -73,6 +73,60 @@ class TestAnthropicUsage:
             "cache_creation": 10,
         }
 
+    def test_1h_cache_write_split_is_reported(self, monkeypatch):
+        _install_anthropic(
+            monkeypatch,
+            types.SimpleNamespace(
+                content=[types.SimpleNamespace(text="0.8")],
+                usage=_Usage(
+                    input_tokens=20,
+                    output_tokens=7,
+                    cache_read_input_tokens=90,
+                    cache_creation_input_tokens=10,
+                    cache_creation=_Usage(ephemeral_5m_input_tokens=6, ephemeral_1h_input_tokens=4),
+                ),
+            ),
+        )
+
+        _, usage = judge_mod._default_complete("claude-sonnet-5", MESSAGES)
+
+        # The 1h subset (2.0x input pricing vs 1.25x for 5m writes) rides alongside the
+        # collapsed cache_creation total; the 5m portion is the remainder and needs no count.
+        assert usage == {
+            "prompt": 120,
+            "completion": 7,
+            "total": 127,
+            "cache_read": 90,
+            "cache_creation": 10,
+            "cache_write_1h": 4,
+        }
+
+    def test_1h_split_survives_a_dict_shaped_breakdown(self, monkeypatch):
+        # An anthropic SDK pin that predates the typed cache_creation field still
+        # surfaces the API's breakdown -- as a raw dict via pydantic extra="allow".
+        _install_anthropic(
+            monkeypatch,
+            types.SimpleNamespace(
+                content=[types.SimpleNamespace(text="0.8")],
+                usage=_Usage(
+                    input_tokens=20,
+                    output_tokens=7,
+                    cache_creation_input_tokens=10,
+                    cache_creation={"ephemeral_5m_input_tokens": 6, "ephemeral_1h_input_tokens": 4},
+                ),
+            ),
+        )
+
+        _, usage = judge_mod._default_complete("claude-sonnet-5", MESSAGES)
+
+        assert usage == {
+            "prompt": 30,
+            "completion": 7,
+            "total": 37,
+            "cache_creation": 10,
+            "cache_write_1h": 4,
+        }
+
     def test_uncached_call_reports_only_the_counts_it_has(self, monkeypatch):
         _install_anthropic(
             monkeypatch,

--- a/tests/eval/test_trace_native.py
+++ b/tests/eval/test_trace_native.py
@@ -457,6 +457,7 @@ class TestLlmJudgeTokenCounts:
     TOTAL = "llm.token_count.total"
     CACHE_READ = "llm.token_count.prompt_details.cache_read"
     CACHE_CREATION = "llm.token_count.prompt_details.cache_creation"
+    CACHE_WRITE_1H = "llm.token_count.prompt_details.cache_write_1h"
 
     @staticmethod
     def _judge(**kw):
@@ -496,13 +497,21 @@ class TestLlmJudgeTokenCounts:
     def test_cache_counts_are_recorded_when_reported(self, memory_exporter, monkeypatch):
         self._stub_default(
             monkeypatch,
-            {"prompt": 120, "completion": 7, "total": 127, "cache_read": 90, "cache_creation": 10},
+            {
+                "prompt": 120,
+                "completion": 7,
+                "total": 127,
+                "cache_read": 90,
+                "cache_creation": 10,
+                "cache_write_1h": 4,
+            },
         )
         _, by = self._run(self._judge(), memory_exporter)
 
         attrs = by["llm_judge:conciseness"].attributes
         assert attrs[self.CACHE_READ] == 90
         assert attrs[self.CACHE_CREATION] == 10
+        assert attrs[self.CACHE_WRITE_1H] == 4
 
     def test_a_provider_reporting_no_usage_records_no_token_attrs(
         self, memory_exporter, monkeypatch

--- a/tests/test_claude_agent_sdk.py
+++ b/tests/test_claude_agent_sdk.py
@@ -182,6 +182,67 @@ async def test_tokens_on_llm_spans_not_on_query_or_task():
             assert s.attributes.get(LLM_PROMPT) is None, f"{s.name} should not carry prompt tokens"
 
 
+@pytest.mark.asyncio
+async def test_1h_cache_write_split_surfaces_as_its_own_attribute():
+    """Anthropic prices 1h-retention cache writes at 2.0x input vs 1.25x for 5m
+    writes and reports the split under usage.cache_creation. Usage lands from
+    the ResultMessage (streamed per-message counts are ignored), so the split
+    must ride from there as an additive attribute next to the collapsed total."""
+    provider, exporter = _provider()
+    messages = [
+        AssistantMessage(
+            [TextBlock("a")],
+            model="claude-sonnet-4",
+            message_id="m1",
+            usage={"input_tokens": 5, "output_tokens": 2},
+        ),
+        ResultMessage(
+            result="ok",
+            usage={
+                "input_tokens": 10,
+                "output_tokens": 4,
+                "cache_creation_input_tokens": 30,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 18,
+                    "ephemeral_1h_input_tokens": 12,
+                },
+            },
+        ),
+    ]
+    await _run(provider, messages)
+
+    llm = _llm_spans(exporter)
+    assert len(llm) == 1
+    attrs = llm[0].attributes
+    assert attrs.get("llm.token_count.prompt_details.cache_creation") == 30
+    assert attrs.get("llm.token_count.prompt_details.cache_write_1h") == 12
+
+
+@pytest.mark.asyncio
+async def test_no_1h_attribute_when_usage_has_no_breakdown():
+    """A result usage without the per-TTL breakdown must not grow a 1h count."""
+    provider, exporter = _provider()
+    messages = [
+        AssistantMessage(
+            [TextBlock("a")],
+            model="claude-sonnet-4",
+            message_id="m1",
+            usage={"input_tokens": 5, "output_tokens": 2},
+        ),
+        ResultMessage(
+            result="ok",
+            usage={"input_tokens": 10, "output_tokens": 4, "cache_creation_input_tokens": 7},
+        ),
+    ]
+    await _run(provider, messages)
+
+    llm = _llm_spans(exporter)
+    assert len(llm) == 1
+    attrs = llm[0].attributes
+    assert attrs.get("llm.token_count.prompt_details.cache_creation") == 7
+    assert attrs.get("llm.token_count.prompt_details.cache_write_1h") is None
+
+
 # --- Step 2: timeline / subagent spans --------------------------------------
 
 

--- a/traceroot/eval/judge.py
+++ b/traceroot/eval/judge.py
@@ -116,12 +116,24 @@ def _anthropic_usage(usage: Any) -> dict[str, int] | None:
     cache_creation = _as_int(getattr(usage, "cache_creation_input_tokens", None))
     prompt = _as_int(getattr(usage, "input_tokens", None)) + cache_read + cache_creation
     completion = _as_int(getattr(usage, "output_tokens", None))
+    # Per-TTL breakdown: the 1h subset is priced at 2.0x input vs 1.25x for the
+    # default 5m writes, so it gets its own count next to the collapsed total
+    # (the 5m portion is the remainder and needs none). On SDK pins that predate
+    # the typed cache_creation field the breakdown arrives as a raw dict (pydantic
+    # extra="allow"), so both shapes must be read.
+    breakdown = getattr(usage, "cache_creation", None)
+    cache_write_1h = _as_int(
+        breakdown.get("ephemeral_1h_input_tokens")
+        if isinstance(breakdown, dict)
+        else getattr(breakdown, "ephemeral_1h_input_tokens", None)
+    )
     counts = {
         "prompt": prompt,
         "completion": completion,
         "total": prompt + completion,
         "cache_read": cache_read,
         "cache_creation": cache_creation,
+        "cache_write_1h": cache_write_1h,
     }
     return {k: v for k, v in counts.items() if v > 0} or None
 
@@ -185,6 +197,7 @@ def _set_token_attributes(usage: dict[str, int]) -> None:
     from traceroot.instrumentation.claude_agent_sdk import (
         LLM_TOKEN_CACHE_CREATION,
         LLM_TOKEN_CACHE_READ,
+        LLM_TOKEN_CACHE_WRITE_1H,
         LLM_TOKEN_TOTAL,
         OI_LLM_TOKEN_COUNT_COMPLETION,
         OI_LLM_TOKEN_COUNT_PROMPT,
@@ -197,6 +210,7 @@ def _set_token_attributes(usage: dict[str, int]) -> None:
         LLM_TOKEN_TOTAL: usage.get("total"),
         LLM_TOKEN_CACHE_READ: usage.get("cache_read"),
         LLM_TOKEN_CACHE_CREATION: usage.get("cache_creation"),
+        LLM_TOKEN_CACHE_WRITE_1H: usage.get("cache_write_1h"),
     }
     for key, value in attributes.items():
         if value:  # absent/zero counts are left off rather than reported as a real zero

--- a/traceroot/instrumentation/claude_agent_sdk.py
+++ b/traceroot/instrumentation/claude_agent_sdk.py
@@ -44,6 +44,10 @@ TOOL_NAME_ATTR = "tool.name"
 LLM_TOKEN_TOTAL = "llm.token_count.total"
 LLM_TOKEN_CACHE_READ = "llm.token_count.prompt_details.cache_read"
 LLM_TOKEN_CACHE_CREATION = "llm.token_count.prompt_details.cache_creation"
+# Anthropic 1h-retention subset of the cache_creation total (2.0x input pricing
+# versus 1.25x for the default 5m writes); additive alongside the total, and the
+# 5m portion is the remainder so it needs no attribute of its own.
+LLM_TOKEN_CACHE_WRITE_1H = "llm.token_count.prompt_details.cache_write_1h"
 GEN_AI_RESPONSE_MODEL = "gen_ai.response.model"
 GEN_AI_TOOL_CALL_ID = "gen_ai.tool.call.id"
 GEN_AI_TOOL_NAME = "gen_ai.tool.name"
@@ -63,6 +67,12 @@ def extract_usage(usage: dict[str, Any] | None) -> dict[str, int]:
     output_tokens = usage.get("output_tokens", 0) or 0
     cache_read = usage.get("cache_read_input_tokens", 0) or 0
     cache_creation = usage.get("cache_creation_input_tokens", 0) or 0
+    cache_creation_detail = usage.get("cache_creation")
+    cache_write_1h = (
+        cache_creation_detail.get("ephemeral_1h_input_tokens", 0) or 0
+        if isinstance(cache_creation_detail, dict)
+        else 0
+    )
 
     prompt_tokens = input_tokens + cache_read + cache_creation
 
@@ -77,6 +87,8 @@ def extract_usage(usage: dict[str, Any] | None) -> dict[str, int]:
         result["prompt_cached_tokens"] = cache_read
     if cache_creation > 0:
         result["prompt_cache_creation_tokens"] = cache_creation
+    if cache_write_1h > 0:
+        result["prompt_cache_write_1h_tokens"] = cache_write_1h
     return result
 
 
@@ -94,6 +106,8 @@ def _set_usage_attrs(span: trace.Span, usage: dict[str, Any] | None) -> None:
         span.set_attribute(LLM_TOKEN_CACHE_READ, metrics["prompt_cached_tokens"])
     if "prompt_cache_creation_tokens" in metrics:
         span.set_attribute(LLM_TOKEN_CACHE_CREATION, metrics["prompt_cache_creation_tokens"])
+    if "prompt_cache_write_1h_tokens" in metrics:
+        span.set_attribute(LLM_TOKEN_CACHE_WRITE_1H, metrics["prompt_cache_write_1h_tokens"])
 
 
 def _set_model(span: trace.Span, model: str | None) -> None:


### PR DESCRIPTION
## Summary

Anthropic prices 1h-retention cache writes at 2.0x base input versus 1.25x for the default 5m writes, and reports the split in the usage payload's `cache_creation` breakdown. Both emitters collapsed it to the single `cache_creation_input_tokens` total, so 1h writes were priced downstream at the 5m rate (a 37.5% undercount on that line item).

## Changes

- **instrumentation/claude_agent_sdk.py** — `extract_usage` reads the `cache_creation` breakdown off the ResultMessage usage dict (the only place usage lands; streamed per-message counts are deliberately ignored) and `_set_usage_attrs` emits `llm.token_count.prompt_details.cache_write_1h` next to the collapsed total.
- **eval/judge.py** — `_anthropic_usage` normalizes the same field from the provider response and the judge span stamps the same attribute. Handles both the typed `CacheCreation` object and a raw-dict breakdown (anthropic SDK pins that predate the typed field still surface it via pydantic `extra="allow"`).

The 1h figure is additive (a subset of the total, which keeps its attribute); the 5m portion is the remainder and needs no count of its own. The attribute spelling is already accepted by the platform's ingest.

## Testing

820 tests green; new cases cover breakdown present/absent on the instrumentation path and object-/dict-shaped breakdowns on the judge path. Ruff clean.

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHNU4fYWfcmJXjYPiF2w3i

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits the Anthropic 1h cache-write token split so downstream pricing no longer charges 1h writes at the 5m rate. Both emitters previously collapsed the `cache_creation` breakdown into one total, undercounting 1h writes by 37.5%; they now emit `llm.token_count.prompt_details.cache_write_1h` next to the existing total.

- The Claude Agent SDK instrumentation reads the breakdown from `ResultMessage` usage; the eval judge normalizes the same field from the provider response.
- Handles both typed `CacheCreation` objects and raw-dict breakdowns from older SDK pins.
- The 1h figure is a subset of the total, so the 5m portion needs no attribute of its own.
- Closes #174.

<sup>Written for commit 7132f6e9cf7049fb5190e4b100f483f4b5165897. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-py/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

